### PR TITLE
[QA-142] Shutdown OpenTelemetry collector at end of test

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -15,18 +15,18 @@ processors:
 
   metricstransform:
     transforms:
-    - include: ^.*$
-      match_type: regexp
-      action: update
-      operations:
-        - action: add_label
-          new_label: build_id
-          new_value: "{ID}"
-    - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
-      match_type: regexp
-      action: combine
-      new_name: k6.checks
-      submatch_case: lower
+      - include: ^.*$
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: build_id
+            new_value: "{ID}"
+      - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
+        match_type: regexp
+        action: combine
+        new_name: k6.checks
+        submatch_case: lower
 
 exporters:
   otlphttp:
@@ -35,9 +35,7 @@ exporters:
       Authorization: "Api-Token {APITOKEN}"
 
 service:
-
   pipelines:
-
     metrics:
       receivers: [statsd, hostmetrics]
       processors: [batch, metricstransform]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,6 +253,8 @@ Resources:
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
             post_build:
               commands:
+                - echo Wait 5 minutes to flush remaining metrics
+                - sleep 300
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |
                   echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,8 +253,10 @@ Resources:
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
             post_build:
               commands:
-                - echo Wait 5 minutes to flush remaining metrics
-                - sleep 300
+                - OTEL_PID=$(pgrep /otel/otelcol-contrib)
+                - kill $OTEL_PID
+                - while kill -0 $OTEL_PID; do sleep 1; done
+                - cat otel.log
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |
                   echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID


### PR DESCRIPTION
##  QA-142

Adding a `kill` command in the post-build to send a `SIGTERM` signal to the OpenTelemetry collector, and wait for it to shutdown gracefully with a while loop