### PR TITLE
[QA-142] Added timeout to OpenTelemetry kill command

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -255,7 +255,8 @@ Resources:
               commands:
                 - OTEL_PID=$(pgrep /otel/otelcol-contrib)
                 - kill $OTEL_PID
-                - while kill -0 $OTEL_PID; do sleep 1; done
+                - TIMEOUT=0
+                - while kill -0 $OTEL_PID && (( TIMEOUT < 300 )); do sleep 1; (( TIMEOUT++ )); done
                 - cat otel.log
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |


### PR DESCRIPTION
## QA-142

### What
Added a 5 minute timeout as a fallback whilst waiting for OpenTelemetry process to terminate in the post-build stage at the end of the test

### Why
The current kill command is not terminating the process in some instances, and is causing the build to hang on an infinite loop