### PR TITLE
[QA-182] Remove Cloudformation stack references

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -223,8 +223,6 @@ Resources:
               TEST_REPORT_DIR: results
               PROFILE: smoke
               SCENARIO: all
-              BACKEND_STACK_NAME: demo-sam-app
-              FRONTEND_STACK_NAME: node-app
               K6_DYNATRACE_DASHBOARD_ID: 1e845440-d013-4472-9d65-2ea21a5cb41a
             parameter-store:
               APP_PASSWORD: "/perfTest/testUserPassword"
@@ -242,14 +240,6 @@ Resources:
             build:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`
-                - echo "Importing output from $BACKEND_STACK_NAME"
-                - |
-                  aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --region "${AWS::Region}" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
-                - eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
-                - echo "Importing output from $FRONTEND_STACK_NAME"
-                - |
-                  aws cloudformation describe-stacks --stack-name "$FRONTEND_STACK_NAME" --region '${AWS::Region}' --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
-                - eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
                 - echo "Run performance test"
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
             post_build:


### PR DESCRIPTION
##  QA-182

### What?
Removing references to CloudFormation stacks in Dev Platform environments

### Why?
These stacks do not exist in the new performance test account