### PR TITLE
[QA-198] Remove legacy publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,23 +12,6 @@ defaults:
 
 jobs:
   dockerBuildAndPush:
-    name: Docker build and push (legacy devplatform accounts)
-    runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Deploy SAM app to ECR (legacy devplatform accounts)
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.2
-        with:
-          artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
-          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          working-directory: ./deploy
-          template-file: template.yaml
-          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-          ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}
-  centralPerformanceAccount:
     name: Docker build and push
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## QA-198

- Removing the workflow action to publish to the legacy dev platform accounts