### PR TITLE
[QA-201] Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global owners
+* @alphagov/di-dev-platform @alphagov/digital-identity-performance-test
+
+# Test Scripts
+/deploy/scripts @alphagov/digital-identity-performance-test


### PR DESCRIPTION
##  QA-201

Adding a `CODEOWNERS` file to specify code owners for the repository.