### PR TITLE
[QA-142]: Reducing the max batch processor size in OTEL config

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -11,7 +11,7 @@ receivers:
 
 processors:
   batch:
-    send_batch_max_size: 16384
+    send_batch_max_size: 1000
 
   metricstransform:
     transforms:


### PR DESCRIPTION
##  QA-142

Changes: Reducing the max batch processor size in OTEL config as recommended:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dynatraceexporter#metric-batching
- https://www.dynatrace.com/support/help/dynatrace-api/basics/access-limit