### PR TITLE
[QA-142]: Enable k6 verbose logging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -248,7 +248,7 @@ Resources:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
+                - k6 run --verbose $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
             post_build:
               commands:
                 - OTEL_PID=$(pgrep /otel/otelcol-contrib)


### PR DESCRIPTION
Changes:

Enabled verbose logging in the k6 run command to investigate the cause of statsd output errors.