### PR TITLE
[QA-142]: Updated OTEL metric export interval config

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,6 +17,7 @@ RUN cd scripts && \
 # -----------------------
 FROM otel/opentelemetry-collector-contrib:0.78.0 as otel
 ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
+ENV OTEL_METRIC_EXPORT_INTERVAL=1000
 
 # ---
 # Run


### PR DESCRIPTION
Changes:

- Reduced the OTEL_METRIC_EXPORT_INTERVAL to 1000 milliseconds from a default value of 60000 milliseconds.