### PR TITLE
[QA-142] Reduce push intervals for StatsD and OTEL

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -24,7 +24,8 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 FROM loadimpact/k6:0.44.1
 COPY --from=otel / /otel
 ENV K6_STATSD_ENABLE_TAGS=true
-ENV OTEL_METRIC_EXPORT_INTERVAL=1000
+ENV K6_STATSD_PUSH_INTERVAL=100ms
+ENV OTEL_METRIC_EXPORT_INTERVAL=100
 ENV OTEL_TEMPLATE=/otel/etc/otelcol/config-template.yaml
 ENV OTEL_CONFIG=/home/k6/config.yaml
 ENV WORKDIR=/home/k6


### PR DESCRIPTION
## QA-142

Changes
- Reducing `K6_STATSD_PUSH_INTERVAL` and `OTEL_METRIC_EXPORT_INTERVAL` to `100` milliseconds

Related:
- https://k6.io/docs/results-output/real-time/statsd/
- https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader
- #117 
