### PR TITLE
[QA-142] Reduced push intervals of StatsD and OTEL to 10ms

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -24,8 +24,8 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 FROM loadimpact/k6:0.44.1
 COPY --from=otel / /otel
 ENV K6_STATSD_ENABLE_TAGS=true
-ENV K6_STATSD_PUSH_INTERVAL=100ms
-ENV OTEL_METRIC_EXPORT_INTERVAL=100
+ENV K6_STATSD_PUSH_INTERVAL=10ms
+ENV OTEL_METRIC_EXPORT_INTERVAL=10
 ENV OTEL_TEMPLATE=/otel/etc/otelcol/config-template.yaml
 ENV OTEL_CONFIG=/home/k6/config.yaml
 ENV WORKDIR=/home/k6


### PR DESCRIPTION
## QA-142 <!--Jira Ticket Number-->

### What?
Reducing the push interval for StatsD and OTEL to 10ms

#### Changes:
- K6_STATSD_PUSH_INTERVAL reduced to 10ms from 100ms
- OTEL_METRIC_EXPORT_INTERVAL reduced to 10 from 100

---

### Why?
We are still observing a discrepancy between statistics (count) in the k6 end of test summary report and Dynatrace statistics. Previous test was conducted with the push interval as 100ms. So reducing this further to see if there will be any improvement.