### PR TITLE
[QA-142]: Increasing StatsD buffer size and push intervals

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -24,8 +24,9 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 FROM loadimpact/k6:0.44.1
 COPY --from=otel / /otel
 ENV K6_STATSD_ENABLE_TAGS=true
-ENV K6_STATSD_PUSH_INTERVAL=10ms
-ENV OTEL_METRIC_EXPORT_INTERVAL=10
+ENV K6_STATSD_BUFFER_SIZE=100
+ENV K6_STATSD_PUSH_INTERVAL=100ms
+ENV OTEL_METRIC_EXPORT_INTERVAL=100
 ENV OTEL_TEMPLATE=/otel/etc/otelcol/config-template.yaml
 ENV OTEL_CONFIG=/home/k6/config.yaml
 ENV WORKDIR=/home/k6


### PR DESCRIPTION
## QA-142

### What?
Investigation of the discrepancy between k6 and dynatrace statistics

#### Changes:
- Increased K6_STATSD_BUFFER_SIZE to 100 (Default 20)
- Increased K6_STATSD_PUSH_INTERVAL and OTEL_METRIC_EXPORT_INTERVAL to 100 milliseconds.

---

### Why?
No improvement observed in the results after reducing the push intervals from 100ms to 10ms.
Increasing the buffer size is to check if there is any difference.
Both the changes have been tested locally and we did not see any difference between the statistics in k6 and the statistics in dynatrace.

---

### Related:
- [K6 Documentation](https://k6.io/docs/results-output/real-time/statsd/)
- #120 
- #118 
- #117 
- #114 
- #113 
- #110 
- #109 
- #100 
- #98
- #55
- #49 