### PR TITLE
[QA-41]: Updated workload model for Account Management scenarios

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -63,10 +63,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 300,
+      maxVUs: 1000,
       stages: [
-        { target: 10, duration: '30m' }, // Ramp up to 30 iterations per second in 30 minutes
-        { target: 10, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'changeEmail'
@@ -77,10 +77,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 300,
+      maxVUs: 1000,
       stages: [
-        { target: 10, duration: '30m' }, // Ramp up to 30 iterations per second in 30 minutes
-        { target: 10, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'changePassword'
@@ -91,10 +91,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 300,
+      maxVUs: 1000,
       stages: [
-        { target: 10, duration: '30m' }, // Ramp up to 30 iterations per second in 30 minutes
-        { target: 10, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'changePhone'
@@ -105,10 +105,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 250,
+      maxVUs: 1000,
       stages: [
-        { target: 10, duration: '30m' }, // Ramp up to 30 iterations per second in 30 minutes
-        { target: 10, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'deleteAccount'

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -63,7 +63,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 1000,
+      maxVUs: 300,
       stages: [
         { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
         { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
@@ -77,7 +77,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 1000,
+      maxVUs: 300,
       stages: [
         { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
         { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
@@ -91,7 +91,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 1000,
+      maxVUs: 300,
       stages: [
         { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
         { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
@@ -105,7 +105,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 1000,
+      maxVUs: 300,
       stages: [
         { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
         { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second


### PR DESCRIPTION
## QA-41 <!--Jira Ticket Number-->

### What?
Updated the workload model of the account management scenarios

#### Changes:
- Target load -  10 iterations per second
- Ramp up duration - 15 minutes
- Steady state - 30 minutes

---

### Why?
This is the proposed workload model for initial performance tests for Accounts.
