### PR TITLE
[QA-215] Change default testing URL

### DIFF
--- a/deploy/scripts/src/common/test.ts
+++ b/deploy/scripts/src/common/test.ts
@@ -11,7 +11,7 @@ export const options: Options = {
 }
 
 export default function (): void {
-  const response = http.get('https://account.gov.uk/')
+  const response = http.get('https://home.build.account.gov.uk/')
   check(response, {
     'is status 200': (r) => r.status === 200
   })


### PR DESCRIPTION
## QA-215

### What?
Changing the URL in the default test script to a non-production URL

#### Changes:
- Changed URL from `https://account.gov.uk/` to `https://home.build.account.gov.uk/` in the default `deploy/scripts/common/test.js` test script

---

### Why?
Performance test scripts should not be making calls against Production sites
