### PR TITLE
[QA-234] Bump node from 16-alpine3.16 to 16-alpine3.18 in deploy/

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------------
 # Typescript > Javascript
 # -----------------------
-FROM node:16-alpine3.16 as node-build
+FROM node:16-alpine3.18 as node-build
 
 ENV WORKDIR=/home/node
 


### PR DESCRIPTION
## QA-234

### What?
Bump `node` version in `deploy/Dockerfile` from `16-alpine3.16` to `16-alpine3.18`
