### PR TITLE
[QA-237] Update k6 Docker repo

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,7 +21,7 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 # ---
 # Run
 # ---
-FROM loadimpact/k6:0.45.0
+FROM grafana/k6:0.45.0
 COPY --from=otel / /otel
 ENV K6_STATSD_ENABLE_TAGS=true
 ENV K6_STATSD_BUFFER_SIZE=100


### PR DESCRIPTION
## QA-237

### What?
Change the Dockerhub repository of the k6 image.

#### Changes:
- `deploy/Dockerfile` - Changed the k6 image from `loadimpact/k6` to `grafana/k6`

---

### Why?
The `loadimpact` Dockerhub repository is being deprecated in future releases in favour of the `grafana` org
