### PR TITLE
[QA-239] Make S3 bucket name globally unique

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -187,7 +187,20 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub ${AWS::StackName}-test-results
+      BucketName:
+        Fn::Join:
+            - '-'
+            - - Ref: AWS::StackName
+              - test-results
+              - Fn::Select:
+                  - 4
+                  - Fn::Split:
+                      - '-'
+                      - Fn::Select:
+                          - 2
+                          - Fn::Split:
+                              - /
+                              - Ref: AWS::StackId
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 365


### PR DESCRIPTION
## QA-239

### What?
Adding a portion of the AWS stack ID to end of the test results S3 bucket name

> **Note** 
> This was deployed to development and the s3 bucket with the new name was created
>
> ![image](https://github.com/alphagov/di-devplatform-performance/assets/110121463/8e6caa4d-babf-48a3-a7b7-5915ad78ebf1)


#### Changes:
- Changed bucket name:
  - From: `${AWS::StackName}-test-results`
  - To: `${AWS::StackName}-test-results-<twelve_digit_stack_id>`

---

### Why?
Buckets deployed to production and non-production would end up with the same name, this adds a portion of the stack ID to the end of the bucket name for global uniqueness 

---

### Related:
- #149 
