### PR TITLE
[QA-240] Fix typo in SCENARIO flag documentation

### DIFF
--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -99,8 +99,8 @@ Parameter store locations must start with the prefix `/perfTest/` in order for t
     |Environment Variable|Example Values|Description|
     |-|-|-|
     |`TEST_SCRIPT`|`accounts/test.js`</br>`authentication/test.js`</br>`common/test.js`<sup>[_default_]</sup></br>`common/unit-tests.js`|Relative path of test script to use, including `.js` extension|
-    |`PROFILE`|`smoke`<sup>[_default_]</sup></br>`stress`</br>`load`|Used to select a named load profile described in the test script. Values should match the keys of a [`ProfileList`](src/utils/config/load-profiles.ts#L4) object|
-    |`SCENARIOS`|`all`<sup>[_default_]</sup></br>`sign_in`</br>`create_account,sign_in`|Comma seperated list of scenarios to enable. Blank strings or `'all'` will default to enabling all scenarios in the selected load profile. Implementation in [`getScenarios`](src/utils/config/load-profiles.ts#L27-L36) function|
+    |`PROFILE`|`smoke`<sup>[_default_]</sup></br>`stress`</br>`load`|Used to select a named load profile described in the test script. Values should match the keys of a [`ProfileList`](src/common/utils/config/load-profiles.ts#L4) object|
+    |`SCENARIO`|`all`<sup>[_default_]</sup></br>`sign_in`</br>`create_account,sign_in`|Comma seperated list of scenarios to enable. Blank strings or `'all'` will default to enabling all scenarios in the selected load profile. Implementation in [`getScenarios`](src/common/utils/config/load-profiles.ts#L27-L36) function|
 
 5. Click 'Start Build'
 


### PR DESCRIPTION
## QA-240

### What?
Minor documentation update

#### Changes:
- Corrected the environment flag to `SCENARIO`
- Updated the location of the link to the `load-profiles.ts` utility

---

### Why?
Typo in the scenario flag, and the link to the utility file was incorrect

