### PR TITLE
[QA-142] Add sleep time to post-build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -314,6 +314,7 @@ Resources:
               commands:
                 - S3_LOCATION=s3://${S3_BUCKET}/${TEST_SCRIPT%.*}/$(date +%F/%T)
                 - aws s3 cp $JSON_RESULTS ${S3_LOCATION}/$JSON_RESULTS
+                - sleep 120
                 - OTEL_PID=$(pgrep /otel/otelcol-contrib)
                 - kill $OTEL_PID
                 - TIMEOUT=0


### PR DESCRIPTION
## QA-142

### What?
Add a sleep time to the post-build to allow time for the latest OLTP metrics to flush

#### Changes:
- Added a 2 minute sleep time to the post-build

---

### Why?
The OpenTelemetry does not support a graceful shutdown, so when the `SIGTERM` is sent it immediately stops collecting/sending metrics. This means that any metrics at the end of the test are being lost, as the collector only exports every 1 minute at a minimum.

---

### Related:
- #55 
