### PR TITLE
Revert "Bump eslint-config-standard-with-typescript from 35.0.0 to 36.0.0 in /deploy/scripts"

### DIFF
--- a/deploy/scripts/.eslintrc.json
+++ b/deploy/scripts/.eslintrc.json
@@ -11,11 +11,7 @@
         "sourceType": "module",
         "project": "**/tsconfig.json"
     },
-    "ignorePatterns": [
-        "build.js",
-        "src/mobile/utils/k6/*.js",
-        "dist/"
-    ],
+    "ignorePatterns": ["src/mobile/utils/k6/*.js"],
     "rules": {
     }
 }

--- a/deploy/scripts/package-lock.json
+++ b/deploy/scripts/package-lock.json
@@ -15,7 +15,7 @@
         "esbuild": "^0.18.11",
         "esbuild-plugin-copy": "^2.1.1",
         "eslint": "^8.44.0",
-        "eslint-config-standard-with-typescript": "^36.0.0",
+        "eslint-config-standard-with-typescript": "^35.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.1.1",
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-36.0.0.tgz",
-      "integrity": "sha512-8ZSEskfrDAkUF2lTQLMT0CBzgRNlx1uIM7l2I7L683dKAXUdHuEL2x+GxuGAsdsoWbx7W7Zv0xF67VCEZXIk0Q==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-35.0.0.tgz",
+      "integrity": "sha512-Xa7DY9GgduZyp0qmXxBF0/dB+Vm4/DgWu1lGpNLJV2d46aCaUxTKDEnkzjUWX/1O9S0a+Dhnw7A4oI0JpYzwtw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^5.50.0",

--- a/deploy/scripts/package.json
+++ b/deploy/scripts/package.json
@@ -11,7 +11,7 @@
     "esbuild": "^0.18.11",
     "esbuild-plugin-copy": "^2.1.1",
     "eslint": "^8.44.0",
-    "eslint-config-standard-with-typescript": "^36.0.0",
+    "eslint-config-standard-with-typescript": "^35.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.1.1",


### PR DESCRIPTION
Reverts alphagov/di-devplatform-performance#171