### PR TITLE
Revert "[QA-142] Replace Statsd with Dynatrace Output Extension"

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,15 +12,6 @@ RUN cd scripts && \
     npm install && \
     node ./build.js
 
-# -------------------------------
-# Build k6 binary with extensions
-# -------------------------------
-FROM golang:1.20-alpine as k6-build
-WORKDIR $GOPATH/src/go.k6.io/k6
-
-RUN go install go.k6.io/xk6/cmd/xk6@v0.9.2
-RUN xk6 build v0.45.0 --with github.com/Dynatrace/xk6-output-dynatrace@latest --output /k6
-
 # -----------------------
 # OpenTelemetry Collector
 # -----------------------
@@ -31,8 +22,10 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 # Run
 # ---
 FROM grafana/k6:0.45.0
-COPY --from=k6-build /k6 /usr/bin/k6
 COPY --from=otel / /otel
+ENV K6_STATSD_ENABLE_TAGS=true
+ENV K6_STATSD_BUFFER_SIZE=100
+ENV K6_STATSD_PUSH_INTERVAL=100ms
 ENV OTEL_METRIC_EXPORT_INTERVAL=100
 ENV OTEL_TEMPLATE=/otel/etc/otelcol/config-template.yaml
 ENV OTEL_CONFIG=/home/k6/config.yaml

--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -1,4 +1,6 @@
 receivers:
+  statsd:
+
   hostmetrics:
     collection_interval: 1m
     scrapers:
@@ -21,6 +23,11 @@ processors:
           - action: add_label
             new_label: build_id
             new_value: "{ID}"
+      - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
+        match_type: regexp
+        action: combine
+        new_name: k6.checks
+        submatch_case: lower
 
 exporters:
   otlphttp:
@@ -35,6 +42,6 @@ service:
 
   pipelines:
     metrics:
-      receivers: [hostmetrics]
+      receivers: [statsd, hostmetrics]
       processors: [batch, metricstransform]
       exporters: [otlphttp]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -309,7 +309,7 @@ Resources:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --tag build_id=$CODEBUILD_BUILD_ID --out output-dynatrace --out json=$JSON_RESULTS
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out statsd --out json=$JSON_RESULTS
             post_build:
               commands:
                 - S3_LOCATION=s3://${S3_BUCKET}/${TEST_SCRIPT%.*}/$(date +%F/%T)


### PR DESCRIPTION
Reverts alphagov/di-devplatform-performance#124

The Dynatrace extension significantly impacted load injector performance:

| StatsD | xk6 Dynatrace Extension |
|--|--|
|![image](https://github.com/alphagov/di-devplatform-performance/assets/110121463/eafb64f6-a581-4f3f-97df-0bc3557a4d9e)|![image](https://github.com/alphagov/di-devplatform-performance/assets/110121463/ec28beb3-bf9c-40fc-8357-aaf4fc41cb83)|

CPU Utilisation for the Dynatrace Extension on the same load test was around 5x higher than using StatsD and OpenTelemetry combined, and memory utilisation was also slightly higher. Metrics also stopped being send to Dynatrace after 6 minutes into the test.

For these reasons, I propose we stick to StatsD output option for now