### PR TITLE
[QA-250] Added 2 BE requests for CIC 

### DIFF
--- a/deploy/scripts/src/cri-kiwi/test.ts
+++ b/deploy/scripts/src/cri-kiwi/test.ts
@@ -208,7 +208,6 @@ export function CIC (): void {
       grant_type: 'authorization_code',
       code: codeUrl,
       redirect_uri: env.envIPVStub + '/redirect'
-
     }, {
       tags: { name: 'B01_CIC_06_SendAuthorizationCode' }
     })

--- a/deploy/scripts/src/cri-kiwi/test.ts
+++ b/deploy/scripts/src/cri-kiwi/test.ts
@@ -207,7 +207,7 @@ export function CIC (): void {
     res = http.post(env.envTarget + '/token', {
       grant_type: 'authorization_code',
       code: codeUrl,
-      redirect_uri: 'https://ipvstub.review-c.build.account.gov.uk/redirect'
+      redirect_uri: env.envIPVStub + '/redirect'
 
     }, {
       tags: { name: 'B01_CIC_06_SendAuthorizationCode' }
@@ -822,12 +822,8 @@ function getClientID (r: Response): string {
 }
 
 function getCodeFromUrl (url: string): string {
-  const urlParts = url.split('?')
-  const queryParams = urlParts[1].split('&')
-  for (const param of queryParams) {
-    const [key, value] = param.split('=')
-    if (key === 'code' && value !== null && typeof value === 'string') return value
-  }
+  const code = url.match(/code=([^&]*)/)
+  if (code?.[1] != null) return code[1]
   fail('Code not found')
 }
 


### PR DESCRIPTION
## [QA-250](https://govukverify.atlassian.net/browse/QA-250)

### What?
Added two new BE requests for covering the CIC journey

#### Changes:
- Added B01_CIC_06_SendAuthorizationCode POST for obtaining the access_token
- Added B01_CIC_07_SendBearerToken POST for obtaining the JWT

---

### Why?
To validate the CIC journey

---




[QA-250]: https://govukverify.atlassian.net/browse/QA-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ