### PR TITLE
[QA-255]: Update the approach for using environment names

### DIFF
--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -101,6 +101,7 @@ Parameter store locations must start with the prefix `/perfTest/` in order for t
     |`TEST_SCRIPT`|`accounts/test.js`</br>`authentication/test.js`</br>`common/test.js`<sup>[_default_]</sup></br>`common/unit-tests.js`|Relative path of test script to use, including `.js` extension|
     |`PROFILE`|`smoke`<sup>[_default_]</sup></br>`stress`</br>`load`|Used to select a named load profile described in the test script. Values should match the keys of a [`ProfileList`](src/common/utils/config/load-profiles.ts#L4) object|
     |`SCENARIO`|`all`<sup>[_default_]</sup></br>`sign_in`</br>`create_account,sign_in`|Comma seperated list of scenarios to enable. Blank strings or `'all'` will default to enabling all scenarios in the selected load profile. Implementation in [`getScenarios`](src/common/utils/config/load-profiles.ts#L27-L36) function|
+    |`ENVIRONMENT`|`build`<sup>[_default_]</sup></br>`staging`|Name of the environment where the test is being conducted. Accepted Values are build/staging depending on the test scenario|
 
 5. Click 'Start Build'
 

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -102,13 +102,11 @@ export function setup (): void {
 const env = {
   ipvCoreStub: __ENV.IDENTITY_CORE_STUB_URL,
   fraudUrl: __ENV.IDENTITY_FRAUD_URL,
-  fraudEnvName: __ENV.IDENTITY_FRAUD_ENV_NAME,
   drivingUrl: __ENV.IDENTITY_DRIVING_URL,
-  drivingEnvName: __ENV.IDENTITY_DRIVING_ENV_NAME,
   orchestratorCoreStub: __ENV.IDENTITY_ORCH_STUB_URL,
   ipvCoreURL: __ENV.IDENTITY_CORE_URL,
-  passportURL: __ENV.IDENTITY_PASSPORT_URL
-
+  passportURL: __ENV.IDENTITY_PASSPORT_URL,
+  envName: __ENV.ENVIRONMENT
 }
 
 const stubCreds = {
@@ -231,7 +229,7 @@ export function fraudScenario1 (): void {
       res = http.post(
         env.ipvCoreStub + '/edit-user',
         {
-          cri: env.fraudEnvName,
+          cri: `fraud-cri-${env.envName}`,
           rowNumber: '197',
           firstName: userDetails.firstName,
           surname: userDetails.lastName,
@@ -334,7 +332,7 @@ export function drivingScenario (): void {
     function () {
       const startTime = Date.now()
       res = http.get(env.ipvCoreStub + '/authorize?cri=' +
-        env.drivingEnvName + '&rowNumber=197',
+        env.envName + '&rowNumber=197',
       {
         headers: { Authorization: `Basic ${encodedCredentials}` },
         tags: { name: 'B02_Driving_01_CoreStuB' }

--- a/deploy/scripts/src/cri-orange/address/test.ts
+++ b/deploy/scripts/src/cri-orange/address/test.ts
@@ -77,7 +77,7 @@ export function addressScenario1 (): void {
     function () {
       const startTime = Date.now()
       res = http.get(
-        env.ipvCoreStub + `/credential-issuer?cri=${env.addressEnvName}`,
+        env.ipvCoreStub + '/credential-issuer?cri=address-cri-' + env.envName,
         {
           headers: { Authorization: `Basic ${encodedCredentials}` },
           tags: { name: 'B02_Address_01_AddressCRIEntryFromStub' }

--- a/deploy/scripts/src/cri-orange/kbv/test.ts
+++ b/deploy/scripts/src/cri-orange/kbv/test.ts
@@ -70,7 +70,7 @@ export function kbvScenario1 (): void {
     function () {
       const startTime = Date.now()
       res = http.get(
-        env.ipvCoreStub + '/authorize?cri=kbv-cri-build&rowNumber=197',
+        env.ipvCoreStub + '/authorize?cri=kbv-cri-' + env.envName + '&rowNumber=197',
         {
           headers: { Authorization: `Basic ${encodedCredentials}` },
           tags: { name: 'B01_KBV_01_CoreStubEditUserContinue' }

--- a/deploy/scripts/src/cri-orange/utils/config.ts
+++ b/deploy/scripts/src/cri-orange/utils/config.ts
@@ -4,8 +4,7 @@ export const env = {
   ipvCoreStub: __ENV.IDENTITY_CORE_STUB_URL,
   kbvEndPoint: __ENV.IDENTITY_KBV_URL,
   addressEndPoint: __ENV.IDENTITY_ADDRESS_URL,
-  kbvEnvName: __ENV.IDENTITY_KBV_ENV_NAME,
-  addressEnvName: __ENV.IDENTITY_ADDRESS_ENV_NAME
+  envName: __ENV.ENVIRONMENT
 }
 
 export const stubCreds = {

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -244,6 +244,9 @@ Resources:
           - Name: SCENARIO
             Type: PLAINTEXT
             Value: all
+          - Name: ENVIRONMENT
+            Type: PLAINTEXT
+            Value: build
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt TestContainerSecurityGroup.GroupId
@@ -277,15 +280,11 @@ Resources:
               ACCOUNT_SIGNIN_URL: "/perfTest/account/accounts/signInUrl"
               DATA_BTM_SQS: "/perfTest/data/btm/consumerOutputSQS"
               DATA_TXMA_SQS: "/perfTest/data/txma/auditSQS"
-              IDENTITY_ADDRESS_ENV_NAME: "/perfTest/identity/orange/addressEnvName"
               IDENTITY_ADDRESS_URL: "/perfTest/identity/orange/addressUrl"
               IDENTITY_CORE_STUB_URL: "/perfTest/identity/coreStubUrl"
               IDENTITY_CORE_URL: "/perfTest/identity/coreUrl"
-              IDENTITY_DRIVING_ENV_NAME: "/perfTest/identity/lime/drivingEnvName"
               IDENTITY_DRIVING_URL: "/perfTest/identity/lime/drivingUrl"
-              IDENTITY_FRAUD_ENV_NAME: "/perfTest/identity/lime/fraudEnvName"
               IDENTITY_FRAUD_URL: "/perfTest/identity/lime/fraudUrl"
-              IDENTITY_KBV_ENV_NAME: "/perfTest/identity/orange/kbvEnvName"
               IDENTITY_KBV_URL: "/perfTest/identity/orange/kbvUrl"
               IDENTITY_KBV_ANSWERS: "/perfTest/identity/orange/kbvAnswers"
               IDENTITY_KIWI_URL: "/perfTest/identity/kiwi/url"


### PR DESCRIPTION
## QA-255 <!--Jira Ticket Number-->

### What?
Updated the approach for using environment names in Orange and Lime CRI scripts

#### Changes:
- Added single ENVIRONMENT variable which is used across each script instead of each scenario.
- Updated CF template to add the environment variable and remove the entries from parameter store section 
- Updated Readme to include instructions.

---

### Why?
To simplify the usage of environment name across scripts and reduce the API calls to SSM parameter store in the perf test AWS account.