### PR TITLE
[QA-256] Accept new terms when signing-in in Authentication script

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -511,6 +511,7 @@ export function signIn (): void {
 
   sleep(1)
 
+  let acceptNewTerms = false
   switch (userData.mfaOption) {
     case 'AUTH_APP': {
       group('POST - /enter-password', () => {
@@ -533,7 +534,6 @@ export function signIn (): void {
 
       sleep(1)
 
-      let acceptNewTerms = false
       group('POST - /enter-authenticator-app-code', () => {
         const totp = new TOTP(credentials.authAppKey)
         const start = Date.now()
@@ -553,23 +553,6 @@ export function signIn (): void {
           ? durations.add(end - start)
           : fail('Checks failed')
       })
-
-      if (acceptNewTerms) {
-        group('POST - /updated-terms-and-conditions', () => {
-          const start = Date.now()
-          res = res.submitForm({
-            fields: { termsAndConditionsResult: 'accept' }
-          })
-          const end = Date.now()
-
-          check(res, {
-            'is status 200': r => r.status === 200,
-            'verify page content': r => (r.body as string).includes('User information')
-          })
-            ? durations.add(end - start)
-            : fail('Checks failed')
-        })
-      }
       break
     }
     case 'SMS': {
@@ -605,16 +588,34 @@ export function signIn (): void {
           }
         )
         const end = Date.now()
+
+        acceptNewTerms = (res.body as string).includes('terms of use update')
         check(res, {
           'is status 200': r => r.status === 200,
-          'verify page content': r => (r.body as string).includes('User information')
+          'verify page content': r => acceptNewTerms || (r.body as string).includes('User information')
         })
           ? durations.add(end - start)
           : fail('Checks failed')
-        csrfToken = getCSRF(res)
       })
       break
     }
+  }
+
+  if (acceptNewTerms) {
+    group('POST - /updated-terms-and-conditions', () => {
+      const start = Date.now()
+      res = res.submitForm({
+        fields: { termsAndConditionsResult: 'accept' }
+      })
+      const end = Date.now()
+
+      check(res, {
+        'is status 200': r => r.status === 200,
+        'verify page content': r => (r.body as string).includes('User information')
+      })
+        ? durations.add(end - start)
+        : fail('Checks failed')
+    })
   }
 
   // 25% of users logout


### PR DESCRIPTION
## QA-256

### What?
Add a check if the new page to accept updated terms and conditions is displayed, and accept them.

#### Changes:
- Added checks for the new page on SMS and Auth App branches
- Added an additional step to accept the updated terms and conditions

---

### Why?
The sign-in journey has a new additional step
