### PR TITLE
[QA-142] Remove metrics debug statements

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -312,19 +312,19 @@ Resources:
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out statsd --out json=$JSON_RESULTS
             post_build:
               commands:
+                - echo "Uploading test results to s3"
                 - S3_LOCATION=s3://${S3_BUCKET}/${TEST_SCRIPT%.*}/$(date +%F/%T)
                 - aws s3 cp $JSON_RESULTS ${S3_LOCATION}/$JSON_RESULTS
+                - echo "Shutting down OpenTelemetry collector"
                 - sleep 120
                 - OTEL_PID=$(pgrep /otel/otelcol-contrib)
                 - kill $OTEL_PID
                 - TIMEOUT=0
                 - while kill -0 $OTEL_PID && (( TIMEOUT < 300 )); do sleep 1; (( TIMEOUT++ )); done
-                - cat otel.log
-                - ifconfig lo
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |
                   echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID
-                - echo Performance test complete
+                - echo "Performance test complete"
 
       Tags:
         - Key: "Name"


### PR DESCRIPTION
## QA-142

### What?
Removing noisy debug statements and adding some console prints to indicate stages in the post-build

#### Changes:
- Removed `cat otel.log` and `ifconfig lo` debug statements for OpenTelemetry collector
- Added `echo` commands to show stages of uploading the file to s3 and shutting down the collector

---

### Why?
The debug statements do not indicate any errors causing this issue, and are adding noise to the end of build logs

---

### Related:
- #130 
- #100
