### PR TITLE
[QA-17] Updated load profile for Authentication scenarios

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -32,7 +32,35 @@ const profiles: ProfileList = {
       exec: 'signIn'
     }
   },
-  singleScenarioStress: {
+  lowVolumeTest: {
+    signUp: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 900,
+      stages: [
+        { target: 30, duration: '5m' }, // Ramps up to 30 iterations per second in 5 minutes
+        { target: 30, duration: '15m' }, // Maintain steady state at 30 iterations per second for 15 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
+      ],
+      exec: 'signUp'
+    },
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 900,
+      stages: [
+        { target: 30, duration: '5m' }, // Ramps up to 30 iterations per second in 5 minutes
+        { target: 30, duration: '15m' }, // Maintain steady state at 30 iterations per second for 15 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
+      ],
+      exec: 'signIn'
+    }
+  },
+  stress: {
     signUp: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
@@ -51,33 +79,11 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 600,
+      maxVUs: 60000,
       stages: [
-        { target: 30, duration: '10m' } // Ramps up to target load
-      ],
-      exec: 'signIn'
-    }
-  },
-  stress: {
-    signUp: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 1,
-      maxVUs: 600,
-      stages: [
-        { target: 15, duration: '15m' } // Ramps up to target load
-      ],
-      exec: 'signUp'
-    },
-    signIn: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 1,
-      maxVUs: 600,
-      stages: [
-        { target: 15, duration: '15m' } // Ramps up to target load
+        { target: 2000, duration: '15m' }, // Ramps up to 100 iterations per second in 15 minutes
+        { target: 2000, duration: '30m' }, // Maintain steady state at 100 iterations per second for 30 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'signIn'
     }

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -38,9 +38,11 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 600,
+      maxVUs: 3000,
       stages: [
-        { target: 30, duration: '10m' } // Ramps up to target load
+        { target: 100, duration: '15m' }, // Ramps up to 100 iterations per second in 15 minutes
+        { target: 100, duration: '30m' }, // Maintain steady state at 100 iterations per second for 30 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'signUp'
     },


### PR DESCRIPTION
## QA-17 <!--Jira Ticket Number-->

### What?
Updated the load profile of sign up scenario

#### Changes:
- Updated the load profile of sign up scenario as described in the volumetric plan,

---

### Why?
To conduct initial stress tests for Auth based on the load profile defined in the NFRs

---

### Related:
- [Performance Test Volumetric Plan](https://docs.google.com/spreadsheets/d/1N8-xvuj013E58T9mdrG5p0e78lEK2ks2U2QPrZ32HtY/edit?usp=sharing)
- [Performance Test NFRs](https://govukverify.atlassian.net/wiki/spaces/DID/pages/3295084564/Performance+SLAs+Performance+Efficiency+SLAs+Incident+Management+Recovery)
