### PR TITLE
[QA-265] Updated load target for ID - Reuse

### DIFF
--- a/deploy/scripts/src/accounts/id-reuse.ts
+++ b/deploy/scripts/src/accounts/id-reuse.ts
@@ -27,8 +27,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 1,
       maxVUs: 45,
       stages: [
-        { target: 3, duration: '15m' }, // Ramps up to target load
-        { target: 3, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 3 iterations/second
+        { target: 1900, duration: '15m' }, // Ramps up to target load
+        { target: 1900, duration: '30m' }, // Steady State of 15 minutes at the ramp up load i.e. 1900 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'idReuse'

--- a/deploy/scripts/src/accounts/id-reuse.ts
+++ b/deploy/scripts/src/accounts/id-reuse.ts
@@ -19,13 +19,30 @@ const profiles: ProfileList = {
     }
 
   },
+  initialLoad: {
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 400,
+      stages: [
+        { target: 30, duration: '15m' }, // Ramps up to target load
+        { target: 30, duration: '30m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+      ],
+      exec: 'idReuse'
+    }
+
+  },
+
   load: {
     idReuse: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 45,
+      maxVUs: 20000,
       stages: [
         { target: 1900, duration: '15m' }, // Ramps up to target load
         { target: 1900, duration: '30m' }, // Steady State of 15 minutes at the ramp up load i.e. 1900 iterations/second


### PR DESCRIPTION
## QA-265

### What?
Updated load target for ID - Reuse

#### Changes:
- It will ramp up in 15 min to 1900 iterations/s and will have a steady state at 1900 iterations/s for 30mins

---

### Why?
To respect the NFRs

---

