### PR TITLE
[QA-266] Added a space between colon and quotation mark in template.yaml

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -311,7 +311,7 @@ Resources:
               ACCOUNT_BRAVO_ID_REUSE_API_KEY: "/perfTest/account/bravo/idReuseApiKey"
               ACCOUNT_BRAVO_ID_REUSE_API_KEY_SUMMARISE: "/perfTest/account/bravo/idReuseApiKeySummarise"
               ACCOUNT_BRAVO_ID_REUSE_MOCK: "/perfTest/account/bravo/idReuseMock"
-              ACCOUNT_BRAVO_ID_REUSE_URL:"/perfTest/account/bravo/idReuseUrl"
+              ACCOUNT_BRAVO_ID_REUSE_URL: "/perfTest/account/bravo/idReuseUrl"
               ACCOUNT_CURR_PHONE: "/perfTest/account/accounts/currPhone"
               ACCOUNT_EMAIL_OTP: "/perfTest/account/fixedEmailOTP"
               ACCOUNT_HOME_URL: "/perfTest/account/accounts/homeUrl"


### PR DESCRIPTION
## [QA-266](https://govukverify.atlassian.net/browse/QA-266)

### What?
Added a space between colon and quotation mark

#### Changes:
- Added a space between colon and quotation mark in template yaml for one of the parameter in parameter-store

---

### Why?
For the script to be run from CodeBuild

---



[QA-266]: https://govukverify.atlassian.net/browse/QA-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ