### PR TITLE
[QA-270] Update PR Checks to Include Merge Queues

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -3,6 +3,7 @@ name: Pre-Merge Lint & Unit Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 defaults:
   run:


### PR DESCRIPTION
## QA-270

### What?
Adding a trigger to the pre-merge PR checks to also run on merge queues

#### Changes:
- Added `merge_group:` trigger to `.github/workflows/pre-merge-checks.yml`

---

### Why?
To enable the Merge Queue we need to run checks on the merge group temporary branches. This will simplify merging multiple pull requests at once.

---

### Related:
- [GitHub Merge Queue Documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
