### PR TITLE
[QA-274]: Added noConnectionsReuse for Address scenario

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -57,6 +57,7 @@ const profiles: ProfileList = {
 const loadProfile = selectProfile(profiles)
 
 export const options: Options = {
+  noConnectionReuse: true,
   scenarios: loadProfile.scenarios,
   thresholds: {
     http_req_duration: ['p(95)<=1000', 'p(99)<=2500'], // 95th percentile response time <=1000ms, 99th percentile response time <=2500ms


### PR DESCRIPTION
## QA-274 <!--Jira Ticket Number-->

### What?
Added noConnectionsReuse for Address scenario

#### Changes:
- `noConnectionsReuse` has been set to `true` for the Address scenario.

---

### Why?
To validate if we see the API gateway rate limit breach errors when not reusing the network connections.

---

### Related
- [k6 Options Reference](https://k6.io/docs/using-k6/k6-options/reference/#no-connection-reuse)