### PR TITLE
DCMAW-6068: Mobile - add custom duration Trend for FE E2E script

### DIFF
--- a/deploy/scripts/src/mobile/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/testSteps/backend.ts
@@ -66,7 +66,7 @@ export function getBiometricTokenV2 (sessionId: string): void {
 
     isStatusCode200(res)
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -88,7 +88,7 @@ export function postFinishBiometricSession (sessionId: string): void {
 
     isStatusCode200(res)
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -107,7 +107,7 @@ export function getRedirect (sessionId: string): {
 
     isStatusCode200(redirectRes)
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
 
     return {
       authorizationCode: redirectRes.json('authorizationCode') as string,

--- a/deploy/scripts/src/mobile/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/testSteps/backend.ts
@@ -1,5 +1,5 @@
 import http from 'k6/http'
-import { group } from 'k6'
+import { fail, group } from 'k6'
 import { uuidv4 } from '../../common/utils/jslib/index'
 import { buildBackendUrl } from '../utils/url'
 import {
@@ -7,6 +7,9 @@ import {
   postTestClientStart
 } from '../utils/test-client'
 import { isStatusCode200, isStatusCode201 } from '../utils/assertions'
+import { Trend } from 'k6/metrics'
+
+const transactionDuration = new Trend('duration')
 
 export function postVerifyAuthorizeRequest (): string {
   let verifyUrl: string
@@ -54,10 +57,16 @@ export function getBiometricTokenV2 (sessionId: string): void {
     const biometricTokenUrl = buildBackendUrl('/biometricToken/v2', {
       authSessionId: sessionId
     })
+
+    const startTime = Date.now()
     const res = http.get(biometricTokenUrl, {
       tags: { name: 'GET /biometricToken/v2' }
     })
+    const endTime = Date.now()
+
     isStatusCode200(res)
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
@@ -70,10 +79,16 @@ export function postFinishBiometricSession (sessionId: string): void {
         biometricSessionId: uuidv4()
       }
     )
+
+    const startTime = Date.now()
     const res = http.post(finishBiometricSessionUrl, null, {
       tags: { name: 'POST /finishBiometricSession' }
     })
+    const endTime = Date.now()
+
     isStatusCode200(res)
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
@@ -83,11 +98,17 @@ export function getRedirect (sessionId: string): {
 } {
   return group('GET /redirect', () => {
     const redirectUrl = buildBackendUrl('/redirect', { sessionId })
+
+    const startTime = Date.now()
     const redirectRes = http.get(redirectUrl, {
       tags: { name: 'GET /redirect' }
     })
+    const endTime = Date.now()
 
     isStatusCode200(redirectRes)
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
+
     return {
       authorizationCode: redirectRes.json('authorizationCode') as string,
       redirectUri: redirectRes.json('redirectUri') as string

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -32,7 +32,7 @@ export function startJourney (): void {
 
     isStatusCode201(testClientRes)
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
     authorizeUrl = parseTestClientResponse(testClientRes, 'WebLocation')
   })
 
@@ -50,7 +50,7 @@ export function startJourney (): void {
       'Are you on a computer or a tablet right now?'
     )
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -68,7 +68,7 @@ export function postSelectDevice (): void {
     validatePageRedirect(res, '/selectSmartphone') &&
     validatePageContent(res, 'Which smartphone are you using?')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -86,7 +86,7 @@ export function postSelectSmartphone (): void {
     validatePageRedirect(res, '/validPassport') &&
     validatePageContent(res, 'Do you have a valid passport?')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -107,7 +107,7 @@ export function postValidPassport (): void {
       'Does your passport have this symbol on the cover?'
     )
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -125,7 +125,7 @@ export function postBiometricChip (): void {
     validatePageRedirect(res, '/iphoneModel') &&
     validatePageContent(res, 'Which iPhone model do you have?')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -146,7 +146,7 @@ export function postIphoneModel (): void {
       'Use your passport and a GOV.UK app to confirm your identity'
     )
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -164,7 +164,7 @@ export function postIdCheckApp (): void {
     validatePageRedirect(res, '/workingCamera') &&
     validatePageContent(res, 'Does your smartphone have a working camera?')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -185,7 +185,7 @@ export function postWorkingCamera (): void {
       'The app uses flashing colours. Do you want to continue?'
     )
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -203,7 +203,7 @@ export function postFlashingWarning (): void {
     validatePageRedirect(res, '/downloadApp') &&
     validatePageContent(res, 'Download the GOV.UK ID Check app')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -224,7 +224,7 @@ export function getRedirect (): void {
     validateLocationHeader(res) &&
     validateQueryParam(res.headers.Location, 'code')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }
 
@@ -245,6 +245,6 @@ export function getAbortCommand (): void {
     validateLocationHeader(res) &&
     validateQueryParam(res.headers.Location, 'error')
       ? transactionDuration.add(endTime - startTime)
-      : fail('Response Validation Failed')
+      : fail()
   })
 }

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -1,5 +1,5 @@
 import http from 'k6/http'
-import { group } from 'k6'
+import { fail, group } from 'k6'
 import { buildFrontendUrl } from '../utils/url'
 import {
   isStatusCode200,
@@ -10,7 +10,13 @@ import {
   validateLocationHeader,
   validateQueryParam
 } from '../utils/assertions'
-import { parseTestClientResponse, postTestClientStart } from '../utils/test-client'
+import {
+  parseTestClientResponse,
+  postTestClientStart
+} from '../utils/test-client'
+import { Trend } from 'k6/metrics'
+
+const transactionDuration = new Trend('duration')
 
 export function getSessionIdFromCookieJar (): string {
   const jar = http.cookieJar()
@@ -20,133 +26,184 @@ export function getSessionIdFromCookieJar (): string {
 export function startJourney (): void {
   let authorizeUrl: string
   group('POST test client /start', () => {
+    const startTime = Date.now()
     const testClientRes = postTestClientStart()
+    const endTime = Date.now()
+
     isStatusCode201(testClientRes)
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
     authorizeUrl = parseTestClientResponse(testClientRes, 'WebLocation')
   })
 
   group('GET /authorize', () => {
-    const authorizeRes = http.get(authorizeUrl,
-      { tags: { name: 'GET /authorize' } })
-    isStatusCode200(authorizeRes)
-    validatePageRedirect(authorizeRes, '/selectDevice')
+    const startTime = Date.now()
+    const authorizeRes = http.get(authorizeUrl, {
+      tags: { name: 'GET /authorize' }
+    })
+    const endTime = Date.now()
+
+    isStatusCode200(authorizeRes) &&
+    validatePageRedirect(authorizeRes, '/selectDevice') &&
     validatePageContent(
       authorizeRes,
       'Are you on a computer or a tablet right now?'
     )
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postSelectDevice (): void {
   group('POST /selectDevice', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/selectDevice'),
       { 'select-device-choice': 'smartphone' },
       { tags: { name: 'POST /selectDevice' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/selectSmartphone')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/selectSmartphone') &&
     validatePageContent(res, 'Which smartphone are you using?')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postSelectSmartphone (): void {
   group('POST /selectSmartphone', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/selectSmartphone'),
       { 'smartphone-choice': 'iphone' },
       { tags: { name: 'POST /selectSmartphone' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/validPassport')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/validPassport') &&
     validatePageContent(res, 'Do you have a valid passport?')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postValidPassport (): void {
   group('POST /validPassport', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/validPassport'),
       { 'select-option': 'yes' },
       { tags: { name: 'POST /validPassport' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/biometricChip')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/biometricChip') &&
     validatePageContent(
       res,
       'Does your passport have this symbol on the cover?'
     )
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postBiometricChip (): void {
   group('POST /biometricChip', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/biometricChip'),
       { 'select-option': 'yes' },
       { tags: { name: 'POST /biometricChip' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/iphoneModel')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/iphoneModel') &&
     validatePageContent(res, 'Which iPhone model do you have?')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postIphoneModel (): void {
   group('POST /iphoneModel', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/iphoneModel'),
       { 'select-option': 'iphone7OrNewer' },
       { tags: { name: 'POST /iphoneModel' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/idCheckApp')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/idCheckApp') &&
     validatePageContent(
       res,
       'Use your passport and a GOV.UK app to confirm your identity'
     )
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postIdCheckApp (): void {
   group('POST /idCheckApp', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/idCheckApp'),
       {},
       { tags: { name: 'POST /idCheckApp' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/workingCamera')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/workingCamera') &&
     validatePageContent(res, 'Does your smartphone have a working camera?')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postWorkingCamera (): void {
   group('POST /workingCamera', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/workingCamera'),
       { 'working-camera-choice': 'yes' },
       { tags: { name: 'POST /workingCamera' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/flashingWarning')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/flashingWarning') &&
     validatePageContent(
       res,
       'The app uses flashing colours. Do you want to continue?'
     )
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
 export function postFlashingWarning (): void {
   group('POST /flashingWarning', () => {
+    const startTime = Date.now()
     const res = http.post(
       buildFrontendUrl('/flashingWarning'),
       { 'flashing-colours-choice': 'yes' },
       { tags: { name: 'POST /flashingWarning' } }
     )
-    isStatusCode200(res)
-    validatePageRedirect(res, '/downloadApp')
+    const endTime = Date.now()
+
+    isStatusCode200(res) &&
+    validatePageRedirect(res, '/downloadApp') &&
     validatePageContent(res, 'Download the GOV.UK ID Check app')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
@@ -155,13 +212,19 @@ export function getRedirect (): void {
     const redirectUrl = buildFrontendUrl('/redirect', {
       sessionId: getSessionIdFromCookieJar()
     })
+
+    const startTime = Date.now()
     const res = http.get(redirectUrl, {
       redirects: 0,
       tags: { name: 'GET /redirect' }
     })
-    isStatusCode302(res)
-    validateLocationHeader(res)
+    const endTime = Date.now()
+
+    isStatusCode302(res) &&
+    validateLocationHeader(res) &&
     validateQueryParam(res.headers.Location, 'code')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }
 
@@ -170,12 +233,18 @@ export function getAbortCommand (): void {
     const abortCommandUrl = buildFrontendUrl('/abortCommand', {
       sessionId: getSessionIdFromCookieJar()
     })
+
+    const startTime = Date.now()
     const res = http.get(abortCommandUrl, {
       redirects: 0,
       tags: { name: 'GET /abortCommand' }
     })
-    isStatusCode302(res)
-    validateLocationHeader(res)
+    const endTime = Date.now()
+
+    isStatusCode302(res) &&
+    validateLocationHeader(res) &&
     validateQueryParam(res.headers.Location, 'error')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
   })
 }


### PR DESCRIPTION
## DCMAW-6068<!--Jira Ticket Number-->

### What?
Added transactionDuration equal with request endTime - startTime for FE E2E test

#### Changes:
- all methods used in the FE E2E test: capturing startTime/endTime before/after request and if assertions are passing changed transactionDuration to equal request endTime - startTime for FE E2E test

---

### Why?
We are interested in the total duration of all requests, including redirects, so in our scripts, we have been adding a custom response time duration metric to track this.

Duration:
![Screenshot 2023-07-20 at 16 57 32](https://github.com/alphagov/di-devplatform-performance/assets/122101235/1b8c2728-7654-49a5-9a7d-8616b629312f)
