### PR TITLE
[QA-261] Add execution role to enable SQS testing

### DIFF
--- a/deploy/scripts/src/common/utils/aws/types.d.ts
+++ b/deploy/scripts/src/common/utils/aws/types.d.ts
@@ -1,0 +1,13 @@
+// AWS CLI Credential Output Format https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples
+export interface AssumeRoleOutput {
+  'AssumedRoleUser': {
+    'Arn': string
+    'AssumedRoleId': string
+  }
+  'Credentials': {
+    'AccessKeyId': string
+    'Expiration': string
+    'SecretAccessKey': string
+    'SessionToken': string
+  }
+}

--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -2,6 +2,7 @@ import { type Options } from 'k6/options'
 import { selectProfile, type ProfileList, describeProfile } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { generateRequest } from './requestGenerator/spotReqGen'
+import { type AssumeRoleOutput } from '../common/utils/aws/types'
 
 const profiles: ProfileList = {
   smoke: {
@@ -52,13 +53,13 @@ const env = {
   sqs_queue: __ENV.IDENTITY_SPOT_SQS
 }
 
+const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.IDENTITY_SPOT_AWS_REGION,
-  accessKeyId: __ENV.IDENTITY_SPOT_AWS_ACCESS_KEY_ID,
-  secretAccessKey: __ENV.IDENTITY_SPOT_AWS_SECRET_ACCESS_KEY,
-  sessionToken: __ENV.IDENTITY_SPOT_AWS_SESSION_TOKEN
+  region: __ENV.AWS_REGION,
+  accessKeyId: credentials.AccessKeyId,
+  secretAccessKey: credentials.SecretAccessKey,
+  sessionToken: credentials.SessionToken
 })
-
 const sqs = new SQSClient(awsConfig)
 
 export function spotScenario (): void {

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -2,6 +2,7 @@ import { type Options } from 'k6/options'
 import { selectProfile, type ProfileList, describeProfile } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
+import { type AssumeRoleOutput } from '../common/utils/aws/types'
 
 const profiles: ProfileList = {
   smoke: {
@@ -94,11 +95,12 @@ const env = {
   sqs_queue: __ENV.DATA_TXMA_SQS
 }
 
+const credentials = (JSON.parse(__ENV.AWS_CREDENTIALS) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.DATA_TXMA_AWS_REGION,
-  accessKeyId: __ENV.DATA_TXMA_AWS_ACCESS_KEY_ID,
-  secretAccessKey: __ENV.DATA_TXMA_AWS_SECRET_ACCESS_KEY,
-  sessionToken: __ENV.DATA_TXMA_AWS_SESSION_TOKEN
+  region: __ENV.AWS_REGION,
+  accessKeyId: credentials.AccessKeyId,
+  secretAccessKey: credentials.SecretAccessKey,
+  sessionToken: credentials.SessionToken
 })
 
 const eventData = {

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -302,9 +302,9 @@ Resources:
           - Name: S3_BUCKET
             Type: PLAINTEXT
             Value: !Ref ResultsBucket
-          - Name: SERVICE_ROLE
+          - Name: EXECUTION_ROLE
             Type: PLAINTEXT
-            Value: !GetAtt CodeBuildServiceRole.Arn
+            Value: !GetAtt PerformanceTesterRole.Arn
           - Name: TEST_SCRIPT
             Type: PLAINTEXT
             Value: common/test.js
@@ -377,11 +377,7 @@ Resources:
                   sed -e "s#{URL}#$K6_DYNATRACE_URL#" -e "s#{APITOKEN}#$K6_DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_ID#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > otel.log 2>&1 &
                 - aws sts get-caller-identity
-                - mkdir ~/.aws/ && touch ~/.aws/config
-                - echo "[profile testprofile]" > ~/.aws/config
-                - echo "role_arn = ${SERVICE_ROLE}" >> ~/.aws/config
-                - echo "credential_source = EcsContainer" >> ~/.aws/config
-                - aws sts get-caller-identity --profile testprofile
+                - aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER
             build:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -376,8 +376,7 @@ Resources:
                 - |
                   sed -e "s#{URL}#$K6_DYNATRACE_URL#" -e "s#{APITOKEN}#$K6_DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_ID#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > otel.log 2>&1 &
-                - aws sts get-caller-identity
-                - aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER
+                - export EXECUTION_CREDENTIALS=$(aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER)
             build:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -134,7 +134,7 @@ Resources:
   PerformanceTesterRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-PerformanceTester"
+      RoleName: !Sub "${AWS::StackName}-PerformanceTesterRole"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -39,7 +39,7 @@ Resources:
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-PerformanceTester"
+      RoleName: !Sub "${AWS::StackName}-PerformanceServiceRole"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -130,6 +130,35 @@ Resources:
               - "ssm:GetParametersByPath"
             Resource:
               - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/perfTest/*" #Create the parameters in AWS Systems Manager Parameter store under this path
+
+  PerformanceTesterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-PerformanceTester"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt CodeBuildServiceRole.Arn
+            Action:
+              - "sts:AssumeRole"
+      PermissionsBoundary:
+        !If [
+          UsePermissionsBoundary,
+          !Ref PermissionsBoundary,
+          !Ref AWS::NoValue,
+        ]
+
+  PerofrmanceTesterPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-PerformanceTesterPolicy-${Environment}
+      Roles:
+        - !Ref PerformanceTesterRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
           - Effect: "Allow"
             Action:
               - "kms:Decrypt"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -272,6 +272,9 @@ Resources:
           - Name: S3_BUCKET
             Type: PLAINTEXT
             Value: !Ref ResultsBucket
+          - Name: SERVICE_ROLE
+            Type: PLAINTEXT
+            Value: !GetAtt CodeBuildServiceRole.Arn
           - Name: TEST_SCRIPT
             Type: PLAINTEXT
             Value: common/test.js
@@ -343,6 +346,12 @@ Resources:
                 - |
                   sed -e "s#{URL}#$K6_DYNATRACE_URL#" -e "s#{APITOKEN}#$K6_DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_ID#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > otel.log 2>&1 &
+                - aws sts get-caller-identity
+                - mkdir ~/.aws/ && touch ~/.aws/config
+                - echo "[profile testprofile]" > ~/.aws/config
+                - echo "role_arn = ${SERVICE_ROLE}" >> ~/.aws/config
+                - echo "credential_source = EcsContainer" >> ~/.aws/config
+                - aws sts get-caller-identity --profile testprofile
             build:
               commands:
                 - start=`date +"%Y-%m-%dT%H:%M:%SZ"`

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -102,6 +102,7 @@ Resources:
           - Effect: Allow
             Action:
               - iam:PassRole
+              - sts:AssumeRole
             Resource: !GetAtt CodeBuildServiceRole.Arn
           - Effect: "Allow"
             Action:


### PR DESCRIPTION
## QA-261

### What?
Add a new execution role which will be used in scripts as credentials to send SQS events to test SQS queues and services which use SQS as an entrypoint

#### Changes:
- `deploy/template.yaml`:
  - Added a new execution role `${AWS::StackName}-PerformanceTesterRole` which will be the role used within the test scripts to call SQS queues. The permissions have been split out so now all the relevant execution permissions are on this role (SQS, Lambda, KMS)
  - Renamed the CodeBuild Service role from `${AWS::StackName}-PerformanceTester` to `${AWS::StackName}-PerformanceServiceRole`
  - Added a step to the pre-build to export the assume-role to an environment variable, for use in scripts
- `.../spot/test.ts` & `.../txma/test.ts`: Updated the script to use the new execution credentials
- `deploy/scripts/src/common/utils/aws/types.d.ts`: Added a new `interface` type to handle parsing of the expected AWS CLI JSON format

---

### Why?
This is to enable SQS testing from our performance testing pipeline, and programmatically pulling credentials into the script to enable testing

---

### Related:
- #180 
