### PR TITLE
[QA-275] Specify unit for 'duration' custom metric

### DIFF
--- a/deploy/scripts/src/accounts/id-reuse.ts
+++ b/deploy/scripts/src/accounts/id-reuse.ts
@@ -108,7 +108,7 @@ export function setup (): void {
   describeProfile(loadProfile)
 }
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 const env = {
   envURL: __ENV.ACCOUNT_BRAVO_ID_REUSE_URL,

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -229,7 +229,7 @@ const phoneData = {
   newPhone: __ENV.ACCOUNT_NEW_PHONE
 }
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function changeEmail (): void {
   let res: Response

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -134,7 +134,7 @@ const credentials = {
   emailOTP: __ENV.ACCOUNT_EMAIL_OTP,
   phoneOTP: __ENV.ACCOUNT_PHONE_OTP
 }
-const durations = new Trend('duration')
+const durations = new Trend('duration', true)
 
 export function signUp (): void {
   let res: Response

--- a/deploy/scripts/src/cri-kiwi/test.ts
+++ b/deploy/scripts/src/cri-kiwi/test.ts
@@ -84,7 +84,7 @@ const env = {
   envTarget: __ENV.IDENTITY_KIWI_TARGET
 }
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function CIC (): void {
   let res: Response

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -254,7 +254,7 @@ const csvDataPassport: PassportUser[] = new SharedArray('csvDataPasport', functi
   })
 })
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function fraudScenario1 (): void {
   let res: Response

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -80,7 +80,7 @@ const csvData1: Address[] = new SharedArray('csvDataAddress', function () {
   })
 })
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function addressScenario1 (): void {
   let res: Response

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -70,7 +70,7 @@ const kbvAnswersOBJ = {
   kbvAnswers: __ENV.IDENTITY_KBV_ANSWERS
 }
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function kbvScenario1 (): void {
   let res: Response

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -95,7 +95,7 @@ const env = {
   ipvCoreURL: __ENV.IDENTITY_CORE_URL
 }
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 const myRate = new Rate('rate')
 
 export function coreScenario1 (): void {

--- a/deploy/scripts/src/mobile/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/testSteps/backend.ts
@@ -9,7 +9,7 @@ import {
 import { isStatusCode200, isStatusCode201 } from '../utils/assertions'
 import { Trend } from 'k6/metrics'
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function postVerifyAuthorizeRequest (): string {
   let verifyUrl: string

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils/test-client'
 import { Trend } from 'k6/metrics'
 
-const transactionDuration = new Trend('duration')
+const transactionDuration = new Trend('duration', true)
 
 export function getSessionIdFromCookieJar (): string {
   const jar = http.cookieJar()


### PR DESCRIPTION
## QA-275

### What?
Changing the definition of the `duration` custom metric to specify that this is a time value (not unit-less)

**Before**
> ![image](https://github.com/alphagov/di-devplatform-performance/assets/110121463/abf9b943-743d-477c-8185-f21054549e2d)

**After**
> ![image](https://github.com/alphagov/di-devplatform-performance/assets/110121463/9484996f-a81d-45c5-90f1-525d6a644eb5)


#### Changes:
- Replaced all `new Trend('duration')` with `new Trend('duration', true)`

---

### Why?
The 'duration' metric measures response time and currently it is being recorded as a unit-less metric. This change specifies that this value is a time (and the unit is milliseconds)

---

### Related:
- [k6 Trend Documentation](https://k6.io/docs/javascript-api/k6-metrics/trend/)
