### PR TITLE
[QA-280] Add caching to pre-merge-checks action

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -21,6 +21,26 @@ jobs:
         with:
           fetch-depth: '0'
 
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('package-lock.json', 'package.json') }}
+          restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Cache pre-commit
+        id: cache-pre-commit
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-pre-commit
+        with:
+          path: ~/.cache/pre-commit/
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
+
       - name: Install dependencies
         run: npm i
 


### PR DESCRIPTION
## QA-280

### What?
Add caching to the pre-merge checks github action to speed up checks and reduce time to install npm packages and pre-commit environments

#### Changes:
- `.github/workflows/pre-merge-checks.yml`:
  - Added `actions/cache@v3` to cache `node_modules` for `npm`
  - Added `actions/cache@v3` to cache `~/.cache/pre-commit/` for `pre-commit`

---

### Why?
The pre-merge checks which run on every PR and before merging to main take a long time currently due to not reusing pre-commit environments. Caching the npm packages and pre-commit environments should reduce unnecessary installation time

---

### Related:
- [Github Cache Documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
