### PR TITLE
[QA-280] Add manual trigger for pre-merge-checks

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
## QA-280

### What?
Add a manual trigger to the the pre merge check github action

#### Changes:
- Add a `workflow_dispatch trigger` to `.github/workflows/pre-merge-checks.yml`
---

### Why?
Pre-commit caches the environments for use in the pre merge checks, but as this action has not been run on the main branch ever, it is not using the cache when running checks on new branches or merge queues. This is causing a slowdown in PR checks as cache misses result in pre-commit needing to create several new environments from scratch which can take 1-2 minutes. This PR adds a manual trigger to this action so we can trigger a cache save on main.

---

### Related:
- [Github Caching Documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
