### PR TITLE
[QA-281] Add TxMA SQS Permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,6 +34,9 @@ Mappings:
   SPOT:
     AWS:
       AccountID: "429671060046"
+  TxMA:
+    AWS:
+      AccountID: "750703655225"
 
 Resources:
   CodeBuildServiceRole:
@@ -150,7 +153,7 @@ Resources:
           !Ref AWS::NoValue,
         ]
 
-  PerofrmanceTesterPolicy:
+  PerformanceTesterPolicy:
     Type: AWS::IAM::Policy
     Properties:
       PolicyName: !Sub ${AWS::StackName}-PerformanceTesterPolicy-${Environment}
@@ -177,11 +180,16 @@ Resources:
               - "sqs:DeleteMessage"
               - "sqs:ChangeMessageVisibility"
             Resource:
-              Fn::Join:
-                - ":"
-                - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
-                  - !FindInMap [SPOT, AWS, AccountID]
-                  - "di-ipv-spot-app-*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
+                    - !FindInMap [SPOT, AWS, AccountID]
+                    - "di-ipv-spot-app-*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
+                    - !FindInMap [TxMA, AWS, AccountID]
+                    - "*"
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"


### PR DESCRIPTION
## QA-281

### What?
Adding permissions to the Performance Test Execution role to be able to call SQS queues in the TxMA Event Processing Account

#### Changes:
- `deploy/template.yaml`: Added TxMA account ID to mappings, and added the account's SQS queues to the SQS permissions on the execution role policy. (Also fixed a typo in the `PerformanceTesterPolicy` name)

---

### Why?
These changes are being made to enable performance testing of SQS queues for TxMA

---

### Related:
- #180 
- #220 
