### PR TITLE
[QA-281] Add TxMA KMS Permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -167,11 +167,16 @@ Resources:
               - "kms:Decrypt"
               - "kms:GenerateDataKey"
             Resource:
-              Fn::Join:
-                - ":"
-                - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
-                  - !FindInMap [SPOT, AWS, AccountID]
-                  - "key/*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
+                    - !FindInMap [SPOT, AWS, AccountID]
+                    - "key/*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
+                    - !FindInMap [TxMA, AWS, AccountID]
+                    - "key/*"
           - Effect: "Allow"
             Action:
               - "sqs:SendMessage"
@@ -189,7 +194,7 @@ Resources:
                   - ":"
                   - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
                     - !FindInMap [TxMA, AWS, AccountID]
-                    - "*"
+                    - "event-processing-*"
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"


### PR DESCRIPTION
## QA-281
### What?
Add permissions to call KMS in TxMA

#### Changes:
- `deploy/template.yaml`:
   - Added the TxMA KMS keys to the execution role permisssions
   - Updated the TxMA SQS queue resource to enforce the `event-processing-` prefix

---

### Why?
To facilitate testing of TxMA SQS queues

---

### Related:
- #232 
- #220 
- #180 
- PLAT-2035
