### PR TITLE
[QA-213] Add Slack notifications to build commands

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,10 +35,11 @@ ENV WORKDIR=/home/k6
 WORKDIR ${WORKDIR}
 
 USER root
-RUN apk add --no-cache aws-cli
+RUN apk add --no-cache aws-cli curl jq
 
 USER k6
 RUN mkdir ${WORKDIR}/scripts
 COPY --from=node-build /home/node/scripts/dist ${WORKDIR}/scripts
+ADD reporting ${WORKDIR}/reporting
 
 ENTRYPOINT ["sh"]

--- a/deploy/reporting/slack.sh
+++ b/deploy/reporting/slack.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Script to handle posting messages to Slack
-# To be called as source in the pipeline with argument 'POST' or 'UPDATE'
-# e.g. `. ./slack.sh POST` or `. ./slack.sh UPDATE`
+# To be called with source in the pipeline with argument 'POST' or 'UPDATE'
+# e.g. `source ./slack.sh POST` or `source ./slack.sh UPDATE`
 
 valid_args=true
 case $1 in

--- a/deploy/reporting/slack.sh
+++ b/deploy/reporting/slack.sh
@@ -37,7 +37,7 @@ esac
 
 if $valid_args; then
     dynatrace_url="${K6_DYNATRACE_URL}/#dashboard;gtf=${CODEBUILD_START_TIME}%20to%20${dashboard_end};id=${K6_DYNATRACE_DASHBOARD_ID};gf=all;es=CUSTOM_DIMENSION-build_id:${CODEBUILD_BUILD_NUMBER}/"
-    message_id=$(curl https://slack.com/api/${api_command} \
+    message_id=$(curl https://www.slack.com/api/${api_command} \
             -X POST \
             -H "Authorization: Bearer ${SLACK_OAUTH_TOKEN}" \
             -H "Content-type: application/json" \

--- a/deploy/reporting/slack.sh
+++ b/deploy/reporting/slack.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Script to handle posting messages to Slack
+# To be called as source in the pipeline with argument 'POST' or 'UPDATE'
+# e.g. `. ./slack.sh POST` or `. ./slack.sh UPDATE`
+
+valid_args=true
+case $1 in
+    "POST") # Send initial message
+        api_command="chat.postMessage"
+        dashboard_end="now"
+        title="*:loading: Performance Test - Build In Progress*"
+        color="#c7c700" # yellow
+        ts_prop=""
+        other_info=""
+        ;;
+
+    "UPDATE") # Update message at end of test
+        api_command="chat.update"
+        dashboard_end=$(date +%s000)
+        if [ $CODEBUILD_BUILD_SUCCEEDING -eq 1 ]; then
+            title="*✅ Performance Test - Build Passed*"
+            color="#00c700" # green
+        else
+            title="*❌ Performance Test - Build Failed*"
+            color="#c70000" # red
+        fi
+        ts_prop='"ts": "'$message_id'",'
+        other_info="\n• Results URI: \`${S3_LOCATION}\`"
+        ;;
+
+    *)
+        echo "Script must have argument in ['POST','UPDATE']"
+        valid_args=false
+        ;;
+esac
+
+if $valid_args; then
+    dynatrace_url="${K6_DYNATRACE_URL}/#dashboard;gtf=${CODEBUILD_START_TIME}%20to%20${dashboard_end};id=${K6_DYNATRACE_DASHBOARD_ID};gf=all;es=CUSTOM_DIMENSION-build_id:${CODEBUILD_BUILD_NUMBER}/"
+    message_id=$(curl https://slack.com/api/${api_command} \
+            -X POST \
+            -H "Authorization: Bearer ${SLACK_OAUTH_TOKEN}" \
+            -H "Content-type: application/json" \
+            -d '{
+    "channel": "'"${SLACK_NOTIFY_CHANNEL}"'",
+    '"${ts_prop}"'
+    "attachments": [
+      {
+        "color": "'"${color}"'",
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "'"${title}"'"
+            }
+          },
+          {
+            "type": "section",
+            "fields": [
+              {
+                "type": "mrkdwn",
+                "text": "*Test Script:* `'"${TEST_SCRIPT}"'`"
+              },
+              {
+                "type": "mrkdwn",
+                "text": "*Profile:* `'"${PROFILE}"'`"
+              },
+              {
+                "type": "mrkdwn",
+                "text": "*Scenarios:* `'"${SCENARIO}"'`"
+              },
+              {
+                "type": "mrkdwn",
+                "text": "*Environment:* `'"${ENVIRONMENT}"'`"
+              }
+            ]
+          },
+          {
+            "type": "divider"
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "• <'"${dynatrace_url}"'|Dynatrace Dashboard>\n• <'"${CODEBUILD_BUILD_URL}"'|CodeBuild>'"${other_info}"'"
+            }
+          },
+          {
+            "type": "context",
+            "elements": [
+              {
+                "type": "plain_text",
+                "text": "#'"${CODEBUILD_BUILD_NUMBER}"'"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+    }' | jq -r '.ts // .')
+
+    echo "Message ID: ${message_id}"
+fi

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -387,6 +387,7 @@ Resources:
               MOBILE_BACKEND_URL: "/perfTest/mobile/backendUrl"
               MOBILE_FRONTEND_URL: "/perfTest/mobile/frontendUrl"
               MOBILE_TEST_CLIENT_EXECUTE_URL: "/perfTest/mobile/testClientUrl"
+              SLACK_OAUTH_TOKEN: "/perfTest/slack/OAuthToken"
           phases:
             pre_build:
               commands:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -394,9 +394,9 @@ Resources:
                   sed -e "s#{URL}#$K6_DYNATRACE_URL#" -e "s#{APITOKEN}#$K6_DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_NUMBER#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > otel.log 2>&1 &
                 - export EXECUTION_CREDENTIALS=$(aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER)
+                - source reporting/slack.sh POST
             build:
               commands:
-                - start=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - echo "Run performance test"
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out statsd --out json=$JSON_RESULTS
             post_build:
@@ -410,9 +410,7 @@ Resources:
                 - kill $OTEL_PID
                 - TIMEOUT=0
                 - while kill -0 $OTEL_PID && (( TIMEOUT < 300 )); do sleep 1; (( TIMEOUT++ )); done
-                - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
-                - |
-                  echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_NUMBER
+                - source reporting/slack.sh UPDATE
                 - echo "Performance test complete"
 
       Tags:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -349,6 +349,7 @@ Resources:
               WORK_DIR: /home/k6/scripts
               JSON_RESULTS: results.gz
               K6_DYNATRACE_DASHBOARD_ID: 1e845440-d013-4472-9d65-2ea21a5cb41a
+              SLACK_NOTIFY_CHANNEL: C05J07H48UE
             parameter-store:
               ACCOUNT_APP_KEY: "/perfTest/account/accounts/appKey"
               ACCOUNT_APP_PASSWORD_NEW: "/perfTest/account/testUserNewPassword"


### PR DESCRIPTION
## QA-213

### What?
Add script to post notifications to Slack at the start and end of test. At the start of the test this script will post an initial 'In Progress' message, and after it will edit the message to update with the status of the build.

#### Changes:
- `deploy/reporting/slack.sh` - Add a bash script which will either post an initial slack message, or update the message based on the current Build status
- `deploy/template.yaml` - Add commands to call the bash script (as source), and environment variables for the Slack OAuth token and the Slack channel to post into
- `deploy/Dockerfile` - Installed `curl` and `jq` to agent image to facilitate calling the Slack API from command line and parsing the result

---

### Why?
To provide notifications of performance tests starting, and give quick links to monitoring dashboard to performance engineers.

---

### Related:
- [Slack API `chat.postMessage()` Documentation](https://api.slack.com/methods/chat.postMessage)
- [Slack API `chat.update()` Documentation](https://api.slack.com/methods/chat.update)
- [Slack API Message Sending Documentation](https://api.slack.com/messaging/sending#publishing)
