### PR TITLE
[QA-285] : Increase wait time between Persist VC and Retrieve VC calls

### DIFF
--- a/deploy/scripts/src/accounts/id-reuse.ts
+++ b/deploy/scripts/src/accounts/id-reuse.ts
@@ -180,7 +180,7 @@ export function persistID (): void {
       : fail('Response Validation Failed')
   })
 
-  sleep(Math.random() * 3)
+  sleep(Math.random() * 2 + 2)
 
   group('R01_persistID_03_Retrieve GET', function () {
     const startTime = Date.now()


### PR DESCRIPTION
## QA-285 <!--Jira Ticket Number-->

### What?
ncrease wait time between Persist VC and Retrieve VC calls

#### Changes:
- This will allow a random wait time between 2-4 seconds between persist VC and retrieve VC calls.

---

### Why?
There were few HTTP-404 errors in previous performance runs as the call to retrieve VC was made before it could be persisted in the DB. The wait time previously was a random value between 0 and 3 seconds.