### PR TITLE
DCMAW-5597: Added load profile 

### DIFF
--- a/deploy/scripts/src/mobile/authorize.test.ts
+++ b/deploy/scripts/src/mobile/authorize.test.ts
@@ -26,10 +26,10 @@ const profiles: ProfileList = {
   load: {
     startJourney: {
       executor: 'ramping-arrival-rate',
-      startRate: 0,
+      startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 50, // Calculation: 100 journeys / second * 0.5 seconds average journey time
-      maxVUs: 200, // Calculation: 100 journeys / second * 2 seconds maximum journey time
+      maxVUs: 300, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR
       stages: [
         { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
         { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min

--- a/deploy/scripts/src/mobile/authorize.test.ts
+++ b/deploy/scripts/src/mobile/authorize.test.ts
@@ -22,6 +22,20 @@ const profiles: ProfileList = {
       ],
       exec: 'authorize'
     }
+  },
+  load: {
+    startJourney: {
+      executor: 'ramping-arrival-rate',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: 50, // Calculation: 100 journeys / second * 0.5 seconds average journey time
+      maxVUs: 200, // Calculation: 100 journeys / second * 2 seconds maximum journey time
+      stages: [
+        { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
+        { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
+      ],
+      exec: 'authorize'
+    }
   }
 }
 


### PR DESCRIPTION
## DCMAW-5597 <!--Jira Ticket Number-->

### What?
Added a load profile to the authorize test accordingly with the ones in the ticket:
- A 15 minutes volume ramp up from 1 request per second to 100 requests per second (0.1 t/s/s NFR)
- A 30 minutes period of sustained volume at 100 requests per second

#### Changes:
- authorize.ts: added load profile

---

### Why?
The full FE E2E test will test the performance of the FE endpoints, simulating concurrent users following the Frontend journey.

---
