### PR TITLE
DCMAW-5598: Add load profile for the frontend E2E journey

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -38,6 +38,20 @@ const profiles: ProfileList = {
       ],
       exec: 'mamIphonePassport'
     }
+  },
+  load: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1700, // Calculation: 100 journeys / second * 17 seconds average journey time
+      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 UF requests + safety)
+      stages: [
+        { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
+        { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
+      ],
+      exec: 'mamIphonePassport'
+    }
   }
 }
 

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -45,7 +45,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1700, // Calculation: 100 journeys / second * 17 seconds average journey time
-      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 UF requests + safety)
+      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
       stages: [
         { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
         { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min


### PR DESCRIPTION
## [DCMAW-5598](https://govukverify.atlassian.net/browse/DCMAW-5598)

### What?
Added a load profile to the frontend E2E test that adheres to the following volumes:

- A 15 minutes volume ramp up from 1 request per second to 100 requests per second (0.1 t/s/s NFR)
- A 30 minutes period of sustained volume at 100 requests per second

#### Changes:
- update the list of profiles `frontend-e2e.test.ts` to include a load profile
    - preAllocatedVUs was calculated by running the `smoke` profile 3 times and collecting an average from those runs
    - maxVUs was calculated by using the value provided by the NFR (2.5 seconds per user-facing request) and multiplying that by the amount of user-facing requests made during the journey.

---

### Why?
A full FE E2E test will test the performance of the FE endpoints, simulating concurrent users following the Frontend journey.

[DCMAW-5598]: https://govukverify.atlassian.net/browse/DCMAW-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ