### PR TITLE
[QA-292] Use `submitForm()` in Authentication script

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -166,14 +166,7 @@ export function signUp (): void {
     const start = Date.now()
     res = res.submitForm({
       fields: {
-        'scopes-email': 'email',
-        'scopes-phone': 'phone',
-        prompt: 'none',
         '2fa': 'Cl.Cm',
-        loc: '',
-        'claims-core-identity': 'https://vocab.account.gov.uk/v1/coreIdentityJWT',
-        'claims-passport': 'https://vocab.account.gov.uk/v1/passport',
-        'claims-address': 'https://vocab.account.gov.uk/v1/address',
         lng: ''
       }
     })
@@ -403,14 +396,7 @@ export function signIn (): void {
     const start = Date.now()
     res = res.submitForm({
       fields: {
-        'scopes-email': 'email',
-        'scopes-phone': 'phone',
-        prompt: 'none',
         '2fa': 'Cl.Cm',
-        loc: '',
-        'claims-core-identity': 'https://vocab.account.gov.uk/v1/coreIdentityJWT',
-        'claims-passport': 'https://vocab.account.gov.uk/v1/passport',
-        'claims-address': 'https://vocab.account.gov.uk/v1/address',
         lng: ''
       }
     })

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -355,7 +355,6 @@ Resources:
               ACCOUNT_APP_KEY: "/perfTest/account/accounts/appKey"
               ACCOUNT_APP_PASSWORD_NEW: "/perfTest/account/testUserNewPassword"
               ACCOUNT_APP_PASSWORD: "/perfTest/account/testUserPassword"
-              ACCOUNT_BASE_URL: "/perfTest/account/authentication/baseUrl"
               ACCOUNT_BRAVO_ID_REUSE_API_KEY: "/perfTest/account/bravo/idReuseApiKey"
               ACCOUNT_BRAVO_ID_REUSE_API_KEY_SUMMARISE: "/perfTest/account/bravo/idReuseApiKeySummarise"
               ACCOUNT_BRAVO_ID_REUSE_MOCK: "/perfTest/account/bravo/idReuseMock"


### PR DESCRIPTION
## QA-292

### What?
Using `Response.submitForm()` in place of the `http.post()` where applicable

This has been validated with smoke tests locally

#### Changes:
- Replaced `http.post()` instances with `Response.submitForm()` in places where we are submitting the form from the previous request response. Also removed any input values which are set to the default.
- Removed the now unused `ACCOUNT_BASE_URL` environment variable, the redirect from the stub handles this instead
- Removed unused `getCSRF()` and `getPhoneNumber()` utility functions

---

### Why?
To simplify the test script and reduce unnecessary hard-coded form input values

---

### Related:
- [`Response.submitForm()` documentation](https://k6.io/docs/javascript-api/k6-http/response/response-submitform/)
