### PR TITLE
[QA-299] Discard response bodies of static resource calls

### DIFF
--- a/deploy/scripts/src/common/utils/request/static.ts
+++ b/deploy/scripts/src/common/utils/request/static.ts
@@ -1,4 +1,4 @@
-import http, { type Response } from 'k6/http'
+import http, { type ObjectBatchRequest, type Response } from 'k6/http'
 import { URL } from '../jslib/url'
 
 // Resolves relative and absolute `src` and `href` paths
@@ -21,5 +21,13 @@ function getResourceURLs (res: Response): string[] {
 
 // Calls a GET request for static resources defined in the HTML page of a response
 export function getStaticResources (res: Response): Response[] {
-  return http.batch(getResourceURLs(res))
+  const urls = getResourceURLs(res)
+  const requests: ObjectBatchRequest[] = urls.map(url => {
+    return {
+      method: 'GET',
+      url,
+      params: { responseType: 'none' }
+    }
+  })
+  return http.batch(requests)
 }


### PR DESCRIPTION
## QA-299

### What?
Add a parameter to static resource batch calls to discard the response body

#### Changes:
- Added `responseType: 'none'` to the batch request definition

---

### Why?
The responses are consuming large amounts of memory in each VU, and we are not using the response bodies for static resource calls 

---

### Related:
- [k6 Params documentation](https://k6.io/docs/javascript-api/k6-http/params/)
