### PR TITLE
[QA-301] Limit static resources to `.account.gov.uk`

### DIFF
--- a/deploy/scripts/src/common/utils/request/static.ts
+++ b/deploy/scripts/src/common/utils/request/static.ts
@@ -16,7 +16,7 @@ function getResourceURLs (res: Response): string[] {
   res.html('link[href]').each((_, el) => { // Link elements with a `href` attribute
     resources.push(resolveUrl(el.attributes().href.value, res.url))
   })
-  return resources
+  return resources.filter(url => new URL(url).hostname.endsWith('.account.gov.uk')) // Only retrieve URLs accessible to the load injector
 }
 
 // Calls a GET request for static resources defined in the HTML page of a response


### PR DESCRIPTION
## QA-301

### What?
Restrict the list of static resources to those in the `*.account.gov.uk` domain

#### Changes:
- Filter resource URLs programmatically found for static resources only to those that include `.account.gov.uk` in the string

---

### Why?
All systems under test will be under the `*.account.gov.uk` domain, so any other resources will be either inaccessible to the egress firewall rules, or will be inadvertently testing a third party system
