### PR TITLE
[QA-303]: Added low volume test profile

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -30,6 +30,34 @@ const profiles: ProfileList = {
       exec: 'drivingLicence'
     }
   },
+  lowVolumeTest: {
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 3000,
+      stages: [
+        { target: 20, duration: '5m' }, // Ramp up to 20 iterations per second in 5 minutes
+        { target: 20, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 20 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+      ],
+      exec: 'passport'
+    },
+    drivingLicence: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 3000,
+      stages: [
+        { target: 20, duration: '5m' }, // Ramp up to 20 iterations per second in 5 minutes
+        { target: 20, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 20 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+      ],
+      exec: 'drivingLicence'
+    }
+  },
   load: {
     passport: {
       executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-303 <!--Jira Ticket Number-->

### What?
Added a low volume test profile for IPV core scenarios.

#### Changes:
- Low volume test profile has been added for both `Passport` and `Driving Licence` routes in the IPV core script.
- Profile Details - Target load is 20 iterations per second, ramp up of 5 minutes and steady state of 30 minutes
---

### Why?
To conduct low volume tests in IPV core build environment. The objective of the test is to validate lambda performance before and after the the upgrade from 11 to 17.