### PR TITLE
[QA-295] Use `submitForm()` in CRI Orange scripts

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -84,9 +84,7 @@ const transactionDuration = new Trend('duration', true)
 
 export function addressScenario1 (): void {
   let res: Response
-  let csrfToken: string
   let fullAddress: string
-  let addDetails: any
   const user1Address = csvData1[exec.scenario.iterationInTest % csvData1.length]
 
   group('B02_Address_01_AddressCRIEntryFromStub  GET', () => {
@@ -102,97 +100,63 @@ export function addressScenario1 (): void {
     isStatusCode200(res) && validatePageContent(res, 'Find your address')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B02_Address_02_SearchPostCode POST', () => {
     const startTime = Date.now()
-    res = http.post(
-      env.addressEndPoint + '/search',
-      {
-        addressSearch: user1Address.postcode,
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
-        tags: { name: 'B02_Address_02_SearchPostCode' }
-      }
-    )
+    res = res.submitForm({
+      fields: { addressSearch: user1Address.postcode },
+      submitSelector: '#continue',
+      params: { tags: { name: 'B02_Address_02_SearchPostCode' } }
+    })
     const endTime = Date.now()
     isStatusCode200(res) && validatePageContent(res, 'Choose your address')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
 
     fullAddress = res.html().find('select[name=addressResults]>option').last().val() ?? fail('Address not found')
-    csrfToken = getCSRF(res)
   })
 
   group('B02_Address_03_SelectAddress POST', () => {
     const startTime = Date.now()
-    res = http.post(
-      env.addressEndPoint + '/results',
-      {
-        addressResults: fullAddress,
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
-        tags: { name: 'B02_Address_03_SelectAddress' }
-      }
-    )
+    res = res.submitForm({
+      fields: { addressResults: fullAddress },
+      submitSelector: '#continue',
+      params: { tags: { name: 'B02_Address_03_SelectAddress' } }
+    })
     const endTime = Date.now()
     isStatusCode200(res) && validatePageContent(res, 'Check your address')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-
-    addDetails = getAddressDetails(res)
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B02_Address_04_VerifyAddress POST', () => {
     const startTime = Date.now()
-    res = http.post(
-      env.addressEndPoint + '/address',
-      {
-        addressFlatNumber: addDetails.flatNumber,
-        addressHouseNumber: addDetails.houseNumber,
-        addressHouseName: addDetails.houseName,
-        adddressStreetName: addDetails.streetName,
-        addressLocality: addDetails.town,
-        addressYearFrom: '2021',
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
-        tags: { name: 'B02_Address_04_VerifyAddress' }
-      }
-    )
+    res = res.submitForm({
+      fields: { addressYearFrom: '2021' },
+      submitSelector: '#continue',
+      params: { tags: { name: 'B02_Address_04_VerifyAddress' } }
+    })
     const endTime = Date.now()
     isStatusCode200(res) && validatePageContent(res, 'Confirm your details')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B02_Address_05_ConfirmDetails POST', () => {
     const startTime1 = Date.now()
-    res = http.post(
-      env.addressEndPoint + '/summary/confirm',
-      {
-        'x-csrf-token': csrfToken
-      },
-      {
+    res = res.submitForm({
+      params: {
         redirects: 1,
-        tags: { name: 'B02_Address_05_ConfirmDetails_AddCRICall' }
+        tags: { name: 'B02_Address_05_ConfirmDetails_AddCRI' }
       }
-    )
+    })
     const endTime1 = Date.now()
     isStatusCode302(res)
       ? transactionDuration.add(endTime1 - startTime1)
@@ -202,7 +166,7 @@ export function addressScenario1 (): void {
     res = http.get(res.headers.Location,
       {
         headers: { Authorization: `Basic ${encodedCredentials}` },
-        tags: { name: 'B02_Address_05_ConfirmDetails_CoreStubCall' }
+        tags: { name: 'B02_Address_05_ConfirmDetails_CoreStub' }
       }
     )
     const endTime2 = Date.now()
@@ -210,27 +174,4 @@ export function addressScenario1 (): void {
       ? transactionDuration.add(endTime2 - startTime2)
       : fail('Response Validation Failed')
   })
-}
-
-function getCSRF (r: Response): string {
-  return r.html().find("input[name='x-csrf-token']").val() ?? ''
-}
-
-interface AddressDetails {
-  flatNumber: string
-  houseNumber: string
-  houseName: string
-  streetName: string
-  town: string
-}
-
-function getAddressDetails (r: Response): AddressDetails {
-  const html = r.html()
-  return {
-    flatNumber: html.find("input[name='addressFlatNumber']").val() ?? '',
-    houseNumber: html.find("input[name='addressHouseNumber']").val() ?? '',
-    houseName: html.find("input[name='addressHouseName']").val() ?? '',
-    streetName: html.find("input[name='addressStreetName']").val() ?? '',
-    town: html.find("input[name='addressLocality']").val() ?? ''
-  }
 }

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -72,7 +72,7 @@ interface Address {
   postcode: string
 }
 
-const csvData1: Address[] = new SharedArray('csvDataAddress', function () {
+const csvData1: Address[] = new SharedArray('csvDataAddress', () => {
   return open('./data/addressCRIData.csv').split('\n').slice(1).map((postcode) => {
     return {
       postcode
@@ -89,28 +89,25 @@ export function addressScenario1 (): void {
   let addDetails: any
   const user1Address = csvData1[exec.scenario.iterationInTest % csvData1.length]
 
-  group(
-    'B02_Address_01_AddressCRIEntryFromStub  GET',
-    function () {
-      const startTime = Date.now()
-      res = http.get(
-        env.ipvCoreStub + '/credential-issuer?cri=address-cri-' + env.envName,
-        {
-          headers: { Authorization: `Basic ${encodedCredentials}` },
-          tags: { name: 'B02_Address_01_AddressCRIEntryFromStub' }
-        }
-      )
-      const endTime = Date.now()
-      isStatusCode200(res) && validatePageContent(res, 'Find your address')
-        ? transactionDuration.add(endTime - startTime)
-        : fail('Response Validation Failed')
-      csrfToken = getCSRF(res)
-    }
-  )
+  group('B02_Address_01_AddressCRIEntryFromStub  GET', () => {
+    const startTime = Date.now()
+    res = http.get(
+      env.ipvCoreStub + '/credential-issuer?cri=address-cri-' + env.envName,
+      {
+        headers: { Authorization: `Basic ${encodedCredentials}` },
+        tags: { name: 'B02_Address_01_AddressCRIEntryFromStub' }
+      }
+    )
+    const endTime = Date.now()
+    isStatusCode200(res) && validatePageContent(res, 'Find your address')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
+    csrfToken = getCSRF(res)
+  })
 
   sleep(Math.random() * 3)
 
-  group('B02_Address_02_SearchPostCode POST', function () {
+  group('B02_Address_02_SearchPostCode POST', () => {
     const startTime = Date.now()
     res = http.post(
       env.addressEndPoint + '/search',
@@ -132,7 +129,7 @@ export function addressScenario1 (): void {
     csrfToken = getCSRF(res)
   })
 
-  group('B02_Address_03_SelectAddress POST', function () {
+  group('B02_Address_03_SelectAddress POST', () => {
     const startTime = Date.now()
     res = http.post(
       env.addressEndPoint + '/results',
@@ -156,7 +153,7 @@ export function addressScenario1 (): void {
 
   sleep(Math.random() * 3)
 
-  group('B02_Address_04_VerifyAddress POST', function () {
+  group('B02_Address_04_VerifyAddress POST', () => {
     const startTime = Date.now()
     res = http.post(
       env.addressEndPoint + '/address',
@@ -184,7 +181,7 @@ export function addressScenario1 (): void {
 
   sleep(Math.random() * 3)
 
-  group('B02_Address_05_ConfirmDetails POST', function () {
+  group('B02_Address_05_ConfirmDetails POST', () => {
     const startTime1 = Date.now()
     res = http.post(
       env.addressEndPoint + '/summary/confirm',

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -82,29 +82,26 @@ export function kbvScenario1 (): void {
   }
   const kbvAnsJSON: kbvAnswers = JSON.parse(kbvAnswersOBJ.kbvAnswers)
 
-  group(
-    'B01_KBV_01_CoreStubEditUserContinue POST',
-    function () {
-      const startTime = Date.now()
-      res = http.get(
-        env.ipvCoreStub + '/authorize?cri=kbv-cri-' + env.envName + '&rowNumber=197',
-        {
-          headers: { Authorization: `Basic ${encodedCredentials}` },
-          tags: { name: 'B01_KBV_01_CoreStubEditUserContinue' }
-        }
-      )
-      const endTime = Date.now()
-      isStatusCode200(res) && validatePageContent(res, 'You can find this amount on your loan agreement')
-        ? transactionDuration.add(endTime - startTime)
-        : fail('Response Validation Failed')
+  group('B01_KBV_01_CoreStubEditUserContinue POST', () => {
+    const startTime = Date.now()
+    res = http.get(
+      env.ipvCoreStub + '/authorize?cri=kbv-cri-' + env.envName + '&rowNumber=197',
+      {
+        headers: { Authorization: `Basic ${encodedCredentials}` },
+        tags: { name: 'B01_KBV_01_CoreStubEditUserContinue' }
+      }
+    )
+    const endTime = Date.now()
+    isStatusCode200(res) && validatePageContent(res, 'You can find this amount on your loan agreement')
+      ? transactionDuration.add(endTime - startTime)
+      : fail('Response Validation Failed')
 
-      csrfToken = getCSRF(res)
-    }
-  )
+    csrfToken = getCSRF(res)
+  })
 
   sleep(Math.random() * 3)
 
-  group('B01_KBV_02_KBVQuestion1 POST', function () {
+  group('B01_KBV_02_KBVQuestion1 POST', () => {
     const startTime = Date.now()
     res = http.post(
       env.kbvEndPoint + '/kbv/question',
@@ -127,7 +124,7 @@ export function kbvScenario1 (): void {
 
   sleep(Math.random() * 3)
 
-  group('B01_KBV_03_KBVQuestion2 POST', function () {
+  group('B01_KBV_03_KBVQuestion2 POST', () => {
     const startTime = Date.now()
     res = http.post(
       env.kbvEndPoint + '/kbv/question',
@@ -150,7 +147,7 @@ export function kbvScenario1 (): void {
 
   sleep(Math.random() * 3)
 
-  group('B01_KBV_04_KBVQuestion3 POST', function () {
+  group('B01_KBV_04_KBVQuestion3 POST', () => {
     const startTime1 = Date.now()
     res = http.post(
       env.kbvEndPoint + '/kbv/question',

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -74,7 +74,6 @@ const transactionDuration = new Trend('duration', true)
 
 export function kbvScenario1 (): void {
   let res: Response
-  let csrfToken: string
   interface kbvAnswers {
     kbvAns1: string
     kbvAns2: string
@@ -95,72 +94,50 @@ export function kbvScenario1 (): void {
     isStatusCode200(res) && validatePageContent(res, 'You can find this amount on your loan agreement')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B01_KBV_02_KBVQuestion1 POST', () => {
     const startTime = Date.now()
-    res = http.post(
-      env.kbvEndPoint + '/kbv/question',
-      {
-        Q00042: kbvAnsJSON.kbvAns1,
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
-        tags: { name: 'B01_KBV_02_KBVQuestion1' }
-      }
-    )
+    res = res.submitForm({
+      fields: { Q00042: kbvAnsJSON.kbvAns1 },
+      params: { tags: { name: 'B01_KBV_02_KBVQuestion1' } },
+      submitSelector: '#continue'
+    })
     const endTime = Date.now()
     isStatusCode200(res) && validatePageContent(res, 'This includes any interest')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B01_KBV_03_KBVQuestion2 POST', () => {
     const startTime = Date.now()
-    res = http.post(
-      env.kbvEndPoint + '/kbv/question',
-      {
-        Q00015: kbvAnsJSON.kbvAns2,
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
-        tags: { name: 'B01_KBV_03_KBVQuestion2' }
-      }
-    )
+    res = res.submitForm({
+      fields: { Q00015: kbvAnsJSON.kbvAns2 },
+      params: { tags: { name: 'B01_KBV_03_KBVQuestion2' } },
+      submitSelector: '#continue'
+    })
     const endTime = Date.now()
     isStatusCode200(res) && validatePageContent(res, 'Think about the amount you agreed to pay back every month')
       ? transactionDuration.add(endTime - startTime)
       : fail('Response Validation Failed')
-
-    csrfToken = getCSRF(res)
   })
 
   sleep(Math.random() * 3)
 
   group('B01_KBV_04_KBVQuestion3 POST', () => {
     const startTime1 = Date.now()
-    res = http.post(
-      env.kbvEndPoint + '/kbv/question',
-      {
-        Q00018: kbvAnsJSON.kbvAns3,
-        continue: '',
-        'x-csrf-token': csrfToken
-      },
-      {
+    res = res.submitForm({
+      fields: { Q00018: kbvAnsJSON.kbvAns3 },
+      params: {
         redirects: 2,
         tags: { name: 'B01_KBV_04_KBVQuestion3_KBVCall' }
-      }
-    )
+      },
+      submitSelector: '#continue'
+    })
     const endTime1 = Date.now()
     isStatusCode302(res)
       ? transactionDuration.add(endTime1 - startTime1)
@@ -178,8 +155,4 @@ export function kbvScenario1 (): void {
       ? transactionDuration.add(endTime2 - startTime2)
       : fail('Response Validation Failed')
   })
-}
-
-function getCSRF (r: Response): string {
-  return r.html().find("input[name='x-csrf-token']").val() ?? ''
 }


### PR DESCRIPTION
## QA-295

### What?
Using `Response.submitForm()` in place of the `http.post()` where applicable in CRI Orange test scripts.

This has been validated with smoke tests locally

#### Changes:
- Replaced `http.post()` instances with `Response.submitForm()` in places where we are submitting the form from the previous request response. Also removed any input values which are set to the default.
- Removed unused `getCSRF()` and `getAddressDetails()` utility functions
---

### Why?
To simplify the test script and reduce unnecessary hard-coded form input values

---

### Related:
- [`Response.submitForm()` documentation](https://k6.io/docs/javascript-api/k6-http/response/response-submitform/)

