### PR TITLE
[QA-312]: Add stress profile for SPOT

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -32,6 +32,21 @@ const profiles: ProfileList = {
       ],
       exec: 'spotScenario'
     }
+  },
+  stress: {
+    spotScenario: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 5000,
+      stages: [
+        { target: 500, duration: '15m' }, // Ramp up to 500 iterations per second in 15 minutes
+        { target: 500, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 500 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+      ],
+      exec: 'spotScenario'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-312 <!--Jira Ticket Number-->

### What?
Added a stress profile for SPOT scenario.

#### Changes:
- Added a stress profile for SPOT scenario with a target and steady state load of 500 iterations per second.

---

### Why?
To conduct a stress test for SPOT at 500 iterations per second.

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
