### PR TITLE
[QA-311] Resolve URLs using `URL` when discovering static resources

### DIFF
--- a/deploy/scripts/src/common/unit-tests.ts
+++ b/deploy/scripts/src/common/unit-tests.ts
@@ -1,7 +1,6 @@
 import { check, group } from 'k6'
 import TOTP from './utils/authentication/totp'
 import { type Profile, type ProfileList, selectProfile } from './utils/config/load-profiles'
-import { resolveUrl } from './utils/request/static'
 import { AWSConfig, SQSClient } from './utils/jslib/aws-sqs'
 import { findBetween, normalDistributionStages, randomIntBetween, randomItem, randomString, uuidv4 } from './utils/jslib'
 import { URL, URLSearchParams } from './utils/jslib/url'
@@ -203,13 +202,6 @@ export default (): void => {
         'getAll()': () => paramsString.getAll('q').join() === '2',
         'append() & delete()': () => paramsObject.toString() === 'search=term&append=New+Value'
       })
-    })
-  })
-
-  group('request/static', () => {
-    check(null, {
-      'Resolve absolute path': () => resolveUrl('https://gov.uk/assets/static/default.css', 'https://gov.uk/page/') === 'https://gov.uk/assets/static/default.css',
-      'Resolve relative path': () => resolveUrl('/assets/script.js', 'https://gov.uk/page/') === 'https://gov.uk/assets/script.js'
     })
   })
 }

--- a/deploy/scripts/src/common/utils/request/static.ts
+++ b/deploy/scripts/src/common/utils/request/static.ts
@@ -1,22 +1,16 @@
 import http, { type ObjectBatchRequest, type Response } from 'k6/http'
 import { URL } from '../jslib/url'
 
-// Resolves relative and absolute `src` and `href` paths
-export function resolveUrl (source: string, url: string): string {
-  if (source[0] !== '/') return source // Absolute paths do not start with a forward slash
-  return new URL(url).origin + source // Includes origin with relative path
-}
-
 // Returns an array of all static resource URLs in the Response HTML body
-function getResourceURLs (res: Response): string[] {
-  const resources: string[] = []
+function getResourceURLs (res: Response): URL[] {
+  const resources: URL[] = []
   res.html('[src]:not(a)').each((_, el) => { // All elements with a `src` attribute excluding anchor elements
-    resources.push(resolveUrl(el.attributes().src.value, res.url))
+    resources.push(new URL(el.attributes().src.value, res.url))
   })
   res.html('link[href]').each((_, el) => { // Link elements with a `href` attribute
-    resources.push(resolveUrl(el.attributes().href.value, res.url))
+    resources.push(new URL(el.attributes().href.value, res.url))
   })
-  return resources.filter(url => new URL(url).hostname.endsWith('.account.gov.uk')) // Only retrieve URLs accessible to the load injector
+  return resources.filter(url => url.hostname.endsWith('.account.gov.uk')) // Only retrieve URLs accessible to the load injector
 }
 
 // Calls a GET request for static resources defined in the HTML page of a response
@@ -25,7 +19,7 @@ export function getStaticResources (res: Response): Response[] {
   const requests: ObjectBatchRequest[] = urls.map(url => {
     return {
       method: 'GET',
-      url,
+      url: url.href,
       params: { responseType: 'none' }
     }
   })


### PR DESCRIPTION
## QA-311

### What?
Updated the calls in `utils/request/static.ts` to use the `URL` constructor to handle resolving URLs

#### Changes:
- `utils/request/static.ts` - Replaced the `resolveUrl()` function with calls to `URL()` constructor with the two arguments `url` and `base`
- `common/unit-tests.ts` - Removed the unit tests for `resolveUrl()` as these are now being handled by `URL` and the remaining functions in `utils/request/static.ts` do not provide an easy way to test without stubbing out the http calls

---

### Why?
This simplifies the utility by not having to handle the URL resolution ourselves, and also handling the URLs as `URL` types and not strings reduces some of the conversion that was previously taking place

---

### Related:
- [Mozilla URL documentation](https://developer.mozilla.org/en-US/docs/Web/API/URL)
