### PR TITLE
[QA-310] Allow Control Tower roles to assume execution role

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -146,6 +146,17 @@ Resources:
               AWS: !GetAtt CodeBuildServiceRole.Arn
             Action:
               - "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              ArnLike:
+                "aws:PrincipalArn":
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-admin_*" # Prod Admin Control Tower Role
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-power-user_*" # Prod Power User Control Tower Role
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-tester_*" # Prod Tester Control Tower Role
       PermissionsBoundary:
         !If [
           UsePermissionsBoundary,


### PR DESCRIPTION
## QA-310

### What?
Allow Production Control Tower Tester/PowerUser/Admin roles to assume the Performance Tester execution role

#### Changes:
- `deploy/template.yaml` - Added the Tester/PowerUser/Admin role ARNs to the trust policy on the `PerformanceTesterRole` to allow them to be assumed

---

### Why?
Control Tower users who have access to the production tester account or above need to be able to assume the Performance Tester role in order to test SQS scripts locally
