### PR TITLE
[QA-313] Fix SQS call incorrect Promise types

### DIFF
--- a/deploy/scripts/src/btm/test.ts
+++ b/deploy/scripts/src/btm/test.ts
@@ -107,14 +107,14 @@ const eventData = {
 
 const sqs = new SQSClient(awsConfig)
 
-export async function sendEvent (): Promise<void> {
+export function sendEvent (): void {
   const messageBody = eventData.payload.replace('UUID', uuidv4())
-  await sqs.sendMessage(env.sqs_queue, messageBody)
+  sqs.sendMessage(env.sqs_queue, messageBody)
 }
 
-export async function sendEventDebug (): Promise<void> {
+export function sendEventDebug (): void {
   const messageBody = eventData.payload.replace('UUID', uuidv4())
-  await sqs.sendMessage(env.sqs_queue, messageBody)
+  sqs.sendMessage(env.sqs_queue, messageBody)
   console.log('1 === debug === env.sqs_queue', env.sqs_queue)
   console.log('2 === debug === awsConfig', awsConfig)
   console.log('3 === debug === payload', eventData.payload)

--- a/deploy/scripts/src/common/utils/jslib/aws-sqs.d.ts
+++ b/deploy/scripts/src/common/utils/jslib/aws-sqs.d.ts
@@ -101,13 +101,13 @@ export class SQSClient {
    * @example
    * const sqs = new SQSClient(awsConfig)
    * const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue'
-   * await sqs.sendMessage(testQueue, JSON.stringify({value: '123'}))
+   * const sentMessage = sqs.sendMessage(testQueue, JSON.stringify({value: '123'}))
    */
   sendMessage (queueUrl: string, messageBody: string, options?: {
     messageDeduplicationId?: string
     messageGroupId?: string
-  }): Promise<{
+  }): {
     id: string
     bodyMD5: string
-  }>
+  }
 }

--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -151,32 +151,32 @@ const awsConfig = new AWSConfig({
 })
 const sqs = new SQSClient(awsConfig)
 
-export async function authEvent (): Promise<void> {
+export function authEvent (): void {
   const payload = generateAuthRequest()
 
   const authEventMessage = {
     messageBody: JSON.stringify(payload)
   }
 
-  await sqs.sendMessage(env.sqs_queue, authEventMessage.messageBody)
+  sqs.sendMessage(env.sqs_queue, authEventMessage.messageBody)
 }
 
-export async function f2fEvent (): Promise<void> {
+export function f2fEvent (): void {
   const payload = generateF2FRequest()
 
   const f2fEventMessage = {
     messageBody: JSON.stringify(payload)
   }
 
-  await sqs.sendMessage(env.sqs_queue, f2fEventMessage.messageBody)
+  sqs.sendMessage(env.sqs_queue, f2fEventMessage.messageBody)
 }
 
-export async function ipvEvent (): Promise<void> {
+export function ipvEvent (): void {
   const payload = generateIPVRequest()
 
   const ipvEventMessage = {
     messageBody: JSON.stringify(payload)
   }
 
-  await sqs.sendMessage(env.sqs_queue, ipvEventMessage.messageBody)
+  sqs.sendMessage(env.sqs_queue, ipvEventMessage.messageBody)
 }

--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -77,7 +77,7 @@ const awsConfig = new AWSConfig({
 })
 const sqs = new SQSClient(awsConfig)
 
-export async function spotScenario (): Promise<void> {
+export function spotScenario (): void {
   const currTime = new Date().toISOString().slice(2, 16).replace(/[-:]/g, '') // YYMMDDTHHmm
   const payload = generateRequest(currTime)
 
@@ -85,5 +85,5 @@ export async function spotScenario (): Promise<void> {
     messageBody: JSON.stringify(payload)
   }
 
-  await sqs.sendMessage(env.sqs_queue, spotMessage.messageBody)
+  sqs.sendMessage(env.sqs_queue, spotMessage.messageBody)
 }

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -109,14 +109,14 @@ const eventData = {
 
 const sqs = new SQSClient(awsConfig)
 
-export async function sendEvent (): Promise<void> {
+export function sendEvent (): void {
   const messageBody = eventData.payload.replace(/UUID/g, () => uuidv4())
-  await sqs.sendMessage(env.sqs_queue, messageBody)
+  sqs.sendMessage(env.sqs_queue, messageBody)
 }
 
-export async function sendEventDebug (): Promise<void> {
+export function sendEventDebug (): void {
   const messageBody = eventData.payload.replace('UUID', uuidv4())
-  await sqs.sendMessage(env.sqs_queue, messageBody)
+  sqs.sendMessage(env.sqs_queue, messageBody)
   console.log('1 === debug === env.sqs_queue', env.sqs_queue)
   console.log('2 === debug === awsConfig', awsConfig)
   console.log('3 === debug === payload', eventData.payload)


### PR DESCRIPTION
## QA-313

### What?
Removed the Promise return types from the `SQSClient.sendMessage()` function, and updated the relevant tests scripts

These changes were tested locally for the SPOT test script

#### Changes:
- `common/utils/jslib/aws-sqs.d.ts`: Removed `Promise<>` from return type of `SQSClient.sendMessage()` function
- `btm/test.ts`, `cri-kiwi/ipvr.ts`, `spot/test.ts`, `txma/test.ts`: Removed `Promise` from return types and removed `async/await`

---

### Why?
Tests were throwing errors with message `Uncaught (in promise) TypeError: Value is not an object: null` when trying to call `SQSClient.sendMessage()` as a `Promise`, the function actually directly returns an object.

---

### Related:
- [k6 jslib `SQSClient.sendMessage()` documentation](https://k6.io/docs/javascript-api/jslib/aws/sqsclient/sqsclient-sendmessage/)