### PR TITLE
[QA-310] Fix Control Tower Role ARNs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -155,8 +155,8 @@ Resources:
               ArnLike:
                 "aws:PrincipalArn":
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-admin_*" # Prod Admin Control Tower Role
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-power-user_*" # Prod Power User Control Tower Role
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-tester_*" # Prod Tester Control Tower Role
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-poweruser_*" # Prod Power User Control Tower Role
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-testers_*" # Prod Tester Control Tower Role
       PermissionsBoundary:
         !If [
           UsePermissionsBoundary,


### PR DESCRIPTION
## QA-310

### What?
Updating Control Tower role names in the CloudFormation template

#### Changes:
- `deploy/template.yaml` - Updated the Control Tower roles names from `...-power-user_...` to `...-poweruser_...` and `...-tester_...` to `...-testers_...`

---

### Why?
The actual Control Tower role ARNs are different to those specified in the template and need to be updated for the assume role to work for those two Control Tower roles

---

### Related:
- #290 
