### PR TITLE
[QA-315] Fix IPVR SQS ARN permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -216,7 +216,7 @@ Resources:
                     - "event-processing-*"
               - Fn::Join:
                   - ":"
-                  - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
+                  - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
                     - !FindInMap [IPVR, AWS, AccountID]
                     - "ipvreturn-*"
           - Effect: "Allow"


### PR DESCRIPTION
## QA-315

### What?
Fix the ARN of the IPVR SQS queue in the template

#### Changes:
- `deploy/template.yaml`: `kms` -> `sqs`
---

### Why?
The SQS arn mistakenly has KMS in it. Fixes the bug introduced in #293 

---

### Related:
- #293 
