### PR TITLE
[QA-316] mask-password flag for amazon-ecr-login action

### DIFF
--- a/.github/workflows/feature-branch-publish.yaml
+++ b/.github/workflows/feature-branch-publish.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true' # pragma: allowlist secret
 
       - name: Upload Fargates to S3
         env:


### PR DESCRIPTION
## QA-316

### What?
Adding the mask-password flag to the amazon-ecr-login.

#### Changes:
- `.github/workflows/feature-branch-publish.yaml`: Added `mask-password: 'true'` flag to `amazon-ecr-login` action

---

### Why?
Currently this flag isn't specified and it has been flagged as a warning in builds that if in debug mode it may expose passwords.

Warning message:
```
Your docker password is not masked. See https://github.com/aws-actions/amazon-ecr-login#docker-credentials for more information.
```

[Example](https://github.com/alphagov/di-devplatform-performance/actions/runs/5974080835/job/16207554693#step:5:19)

---

### Related:
- [Action documentaiton](https://github.com/aws-actions/amazon-ecr-login#docker-credentials)
