### PR TITLE
Updated load profile for Validate User scenario for low volume test

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -130,10 +130,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 3000,
+      maxVUs: 300,
       stages: [
-        { target: 100, duration: '15m' }, // Ramp up to 100 iterations per second in 15 minutes
-        { target: 100, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 100 iterations/second
+        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'validateUser'

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -132,9 +132,9 @@ const profiles: ProfileList = {
       preAllocatedVUs: 1,
       maxVUs: 300,
       stages: [
-        { target: 10, duration: '15m' }, // Ramp up to 10 iterations per second in 15 minutes
-        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
-        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+        { target: 10, duration: '3m' }, // Ramp up to 10 iterations per second in 3 minutes
+        { target: 10, duration: '6m' }, // Steady State of 6 minutes at the ramp up load i.e. 10 iterations/second
+        { target: 0, duration: '1m' } // Ramp down duration of 1 minute.
       ],
       exec: 'validateUser'
     }


### PR DESCRIPTION
## QA-333 <!--Jira Ticket Number-->

### What?
Updated load profile for Accounts - Validate User scenario to carry out low volume test

#### Changes:
Load profile:
- Max VUs: 300

Ramp up stage:
- Target: 10
- Duration: 3 minutes

Steady State:
- Target: 10
- Duration: 6 minutes

---

### Why?
To carry out low volume tests to test to test the concurrent user production issue

---

### Related:
- [OLH-1093](https://govukverify.atlassian.net/browse/OLH-1093)


[OLH-1093]: https://govukverify.atlassian.net/browse/OLH-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ