### PR TITLE
[QA-334] Add permissions to invoke contra-indicators lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,6 +34,9 @@ Mappings:
   SPOT:
     AWS:
       AccountID: "429671060046"
+  ContraIndicators:
+    AWS:
+      AccountID: "755415363251"
   TxMA:
     AWS:
       AccountID: "750703655225"
@@ -223,11 +226,16 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              Fn::Join:
-                - ":"
-                - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
-                  - !FindInMap [SPOT, AWS, AccountID]
-                  - "function:*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
+                    - !FindInMap [SPOT, AWS, AccountID]
+                    - "function:*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
+                    - !FindInMap [ContraIndicators, AWS, AccountID]
+                    - "function:*"
 
   VPCTestPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
## QA-334

### What?
Add permissions to execution role invoke the contra-indicators lambda

#### Changes:
- `deploy/template.yml`: Added `lambda:InvokeFunction` permissions to the execution role for the contra-indicators build account
---

### Why?
In order to performance test the CIMIT system

---

### Related:
- #180 
