### PR TITLE
[QA-338] : Updated IPVR scripts for smoke tests

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -3,6 +3,7 @@ import { selectProfile, type ProfileList, describeProfile } from '../common/util
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { generateAuthRequest, generateF2FRequest, generateIPVRequest } from './requestGenerator/ipvrReqGen'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
+import { uuidv4 } from '../common/utils/jslib/index'
 
 const profiles: ProfileList = {
   smoke: {
@@ -115,17 +116,19 @@ const awsConfig = new AWSConfig({
 const sqs = new SQSClient(awsConfig)
 
 export function authEvent (): void {
-  const authPayload = generateAuthRequest()
-
+  const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
+  const signinJourneyID = uuidv4()
+  const authPayload = generateAuthRequest(userID, signinJourneyID)
   const authEventMessage = JSON.stringify(authPayload)
-
   sqs.sendMessage(env.sqs_queue, authEventMessage)
 }
 
 export function allEvents (): void {
-  const authPayload = generateAuthRequest()
-  const f2fPayload = generateF2FRequest()
-  const ipvPayload = generateIPVRequest()
+  const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
+  const signinJourneyID = uuidv4()
+  const authPayload = generateAuthRequest(userID, signinJourneyID)
+  const f2fPayload = generateF2FRequest(userID, signinJourneyID)
+  const ipvPayload = generateIPVRequest(userID, signinJourneyID)
   sqs.sendMessage(env.sqs_queue, JSON.stringify(authPayload))
   sqs.sendMessage(env.sqs_queue, JSON.stringify(f2fPayload))
   sqs.sendMessage(env.sqs_queue, JSON.stringify(ipvPayload))

--- a/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqFormat.ts
+++ b/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqFormat.ts
@@ -4,7 +4,7 @@ export interface AUTH_IPV_AUTHORISATION_REQUESTED {
   clientLandingPageUrl: string
   event_name: string
   rp_name: string
-  timestamp: string
+  timestamp: number
   timestamp_formatted: string
   user: {
     user_id: string
@@ -19,7 +19,7 @@ export interface F2F_YOTI_START {
   clientLandingPageUrl: string
   event_name: string
   rp_name: string
-  timestamp: string
+  timestamp: number
   timestamp_formatted: string
   user: {
     user_id: string
@@ -33,7 +33,7 @@ export interface IPV_F2F_CRI_VC_CONSUMED {
   clientLandingPageUrl: string
   event_name: string
   rp_name: string
-  timestamp: string
+  timestamp: number
   timestamp_formatted: string
   user: {
     user_id: string

--- a/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqGen.ts
+++ b/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqGen.ts
@@ -1,11 +1,7 @@
 import { type AUTH_IPV_AUTHORISATION_REQUESTED, type F2F_YOTI_START, type IPV_F2F_CRI_VC_CONSUMED } from '../requestGenerator/ipvrReqFormat'
 import { uuidv4, randomString } from '../../common/utils/jslib/index'
 
-const userID = uuidv4()
-const signinJourneyID = uuidv4()
-const userURN = `urn:fdc:gov.uk:2022:${userID}`
-
-export function generateAuthRequest (): AUTH_IPV_AUTHORISATION_REQUESTED {
+export function generateAuthRequest (userID: string, signinJourneyID: string): AUTH_IPV_AUTHORISATION_REQUESTED {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),
@@ -13,17 +9,17 @@ export function generateAuthRequest (): AUTH_IPV_AUTHORISATION_REQUESTED {
     clientLandingPageUrl: 'https://www.gov.uk/request-copy-criminal-record',
     event_name: 'AUTH_IPV_AUTHORISATION_REQUESTED',
     rp_name: 'replay',
-    timestamp: Math.floor(Date.now() / 1000).toString(),
+    timestamp: Date.now(),
     timestamp_formatted: timestamp,
     user: {
-      user_id: userURN,
+      user_id: userID,
       email: 'test.user@digital.cabinet-office.gov.uk',
       govuk_signin_journey_id: signinJourneyID
     }
   }
 }
 
-export function generateF2FRequest (): F2F_YOTI_START {
+export function generateF2FRequest (userID: string, signinJourneyID: string): F2F_YOTI_START {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),
@@ -31,7 +27,7 @@ export function generateF2FRequest (): F2F_YOTI_START {
     clientLandingPageUrl: 'https://www.gov.uk/request-copy-criminal-record',
     event_name: 'F2F_YOTI_START',
     rp_name: 'replay',
-    timestamp: Date.now().toString().substring(0, 10),
+    timestamp: Date.now(),
     timestamp_formatted: timestamp,
     user: {
       user_id: userID,
@@ -40,7 +36,7 @@ export function generateF2FRequest (): F2F_YOTI_START {
   }
 }
 
-export function generateIPVRequest (): IPV_F2F_CRI_VC_CONSUMED {
+export function generateIPVRequest (userID: string, signinJourneyID: string): IPV_F2F_CRI_VC_CONSUMED {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),
@@ -48,10 +44,10 @@ export function generateIPVRequest (): IPV_F2F_CRI_VC_CONSUMED {
     clientLandingPageUrl: 'https://www.gov.uk/request-copy-criminal-record',
     event_name: 'IPV_F2F_CRI_VC_CONSUMED',
     rp_name: 'replay',
-    timestamp: Date.now().toString().substring(0, 10),
+    timestamp: Date.now(),
     timestamp_formatted: timestamp,
     user: {
-      user_id: userURN,
+      user_id: userID,
       govuk_signin_journey_id: signinJourneyID
     },
     restricted: {


### PR DESCRIPTION
## QA-338<!--Jira Ticket Number-->

### What?
Updated IPVR script for smoke test of all three events

#### Changes:
- Updated the user ID creation approach to ensure same user ID is added for all 3 events in the `allEvents` scenario.
- Updated `timestamp` type to `number`

---

### Why?
Smoke test for IPVR was failing as `timestamp` was assigned `string` type. Additionally, each VU was generating same user ID  in every iteration. Changes have been done to tackle both the issues.