### PR TITLE
[QA-346] Use xk6 extension for statsd output

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,6 +12,15 @@ RUN cd scripts && \
     npm install && \
     npm start
 
+# -------------------------------
+# Build k6 binary with extensions
+# -------------------------------
+FROM golang:1.20-alpine as k6-build
+WORKDIR $GOPATH/src/go.k6.io/k6
+
+RUN go install go.k6.io/xk6/cmd/xk6@v0.9.2
+RUN xk6 build v0.47.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --output /k6
+
 # -----------------------
 # OpenTelemetry Collector
 # -----------------------
@@ -21,7 +30,8 @@ ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 # ---
 # Run
 # ---
-FROM grafana/k6:0.46.0
+FROM grafana/k6:0.47.0
+COPY --from=k6-build /k6 /usr/bin/k6
 COPY --from=otel / /otel
 ENV K6_STATSD_ENABLE_TAGS=true
 ENV K6_STATSD_BUFFER_SIZE=100

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -448,7 +448,7 @@ Resources:
             build:
               commands:
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out statsd --out json=$JSON_RESULTS
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS
             post_build:
               commands:
                 - echo "Uploading test results to s3"


### PR DESCRIPTION
## QA-346

### What?
Replacing the k6 default image with xk6 with the statsd output extension

#### Changes:
- `deploy/Dockerfile`: Added xk6 build using the output-statsd extension to create the k6 binary
- `deploy/template.yaml`: Updated the output flag on the `k6 run` command

---

### Why?
In the k6 [v0.47.0 release](https://github.com/grafana/k6/releases/tag/v0.47.0) the statsd output option is now deprecated, and planned to be removed in a future release. This has now been moved to a xk6 extension, this PR ensures future releases will be compatible with our current reporting pipeline

---

### Related:
- #175 
- #124 
- #29 