### PR TITLE
[QA-347]: Add low volume profile for SPOT

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -18,6 +18,21 @@ const profiles: ProfileList = {
       exec: 'spotScenario'
     }
   },
+  lowVolumeTest: {
+    spotScenario: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 500,
+      stages: [
+        { target: 50, duration: '15m' }, // Ramp up to 50 iterations per second in 15 minutes
+        { target: 50, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 50 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
+      ],
+      exec: 'spotScenario'
+    }
+  },
   load: {
     spotScenario: {
       executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-347 <!--Jira Ticket Number-->

### What?
Add a low volume profile for SPOT scenario.

#### Changes:
- Added a low volume profile with target load of 50 iterations per hour.

---

### Why?
To conduct a low volume test before and after merging the changes in [QA-346](https://govukverify.atlassian.net/browse/QA-346)

---

### Related:
- [QA-346](https://govukverify.atlassian.net/browse/QA-346)


[QA-346]: https://govukverify.atlassian.net/browse/QA-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-346]: https://govukverify.atlassian.net/browse/QA-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ